### PR TITLE
[ci] add dispatch to cpython after release

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -182,6 +182,19 @@ jobs:
             --latest \
             release-assets/*.tar.bz2
 
+      - name: Trigger Dependent Workflows
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+        run: |
+          echo "Triggering cpython workflow..."
+          gh api repos/nanvix/cpython/dispatches \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -f event_type="libffi-release" \
+            -f "client_payload[nanvix_sha]=${NANVIX_SHA}" \
+            -f "client_payload[libffi_tag]=${GITHUB_SHA::7}-nanvix-${NANVIX_SHA}" || echo "::warning::Failed to trigger cpython workflow"
+
   report-failure:
     needs: [build]
     if: >-


### PR DESCRIPTION
Trigger cpython CI workflow when libffi releases a new build, completing the dependency chain: nanvix → libffi → cpython.