### PR TITLE
ci: add INSTALL_PREFIX to CI Build step for portable packages

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -98,7 +98,8 @@ jobs:
       - name: Build
         run: |
           make -f Makefile.nanvix CONFIG_NANVIX=y \
-            NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" all
+            NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" \
+            INSTALL_PREFIX="/sysroot" all
 
       - name: Smoke Tests
         run: |


### PR DESCRIPTION
Add INSTALL_PREFIX=/sysroot to the CI Build step to ensure configure --prefix uses a portable path, consistent with sqlite and openssl submodules.

Without this, the ephemeral CI runner path gets baked into the configure prefix, which can affect pkg-config (.pc) files.

Validated locally: all 4 platform/process-mode configurations pass (build, smoke, integration, functional, package, verify-package) with zero skips.