### PR TITLE
ci: implement best-effort release strategy

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -175,7 +175,7 @@ jobs:
 
   release:
     needs: [get-nanvix-info, build]
-    if: github.event_name != 'pull_request'
+    if: ${{ !cancelled() && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     env:
       NANVIX_SHA: ${{ needs.get-nanvix-info.outputs.sha }}
@@ -185,6 +185,7 @@ jobs:
 
       - name: Download All Artifacts
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           path: release-artifacts
           pattern: libffi-*
@@ -193,7 +194,13 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p release-assets
-          find release-artifacts -name "*.tar.bz2" -exec cp {} release-assets/ \;
+          find release-artifacts -name "*.tar.bz2" -exec cp {} release-assets/ \; 2>/dev/null || true
+          ASSET_COUNT=$(find release-assets -name "*.tar.bz2" 2>/dev/null | wc -l)
+          echo "Found $ASSET_COUNT release asset(s)"
+          if [[ "$ASSET_COUNT" -eq 0 ]]; then
+            echo "::error::No release assets found — all matrix builds failed"
+            exit 1
+          fi
           ls -la release-assets/
 
       - name: Get Nanvix Release Info
@@ -260,11 +267,11 @@ jobs:
             -f "client_payload[libffi_tag]=${RELEASE_TAG}" || echo "::warning::Failed to trigger cpython workflow"
 
   report-failure:
-    needs: [build]
+    needs: [build, release]
     if: >-
       ${{ always() &&
           (github.event_name == 'repository_dispatch' || github.event_name == 'schedule' || github.event_name == 'push') &&
-          needs.build.result == 'failure' }}
+          needs.release.result == 'failure' }}
     runs-on: ubuntu-latest
     steps:
       - name: Create failure issue

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -184,6 +184,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download All Artifacts
+        id: download-artifacts
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
@@ -194,11 +195,14 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p release-assets
+          if [[ "${{ steps.download-artifacts.outcome }}" == "failure" ]]; then
+            echo "::warning::Artifact download step failed — this may indicate an API or network issue"
+          fi
           find release-artifacts -name "*.tar.bz2" -exec cp {} release-assets/ \; 2>/dev/null || true
           ASSET_COUNT=$(find release-assets -name "*.tar.bz2" 2>/dev/null | wc -l)
           echo "Found $ASSET_COUNT release asset(s)"
           if [[ "$ASSET_COUNT" -eq 0 ]]; then
-            echo "::error::No release assets found — all matrix builds failed"
+            echo "::error::No release assets found — all matrix builds may have failed or artifact retrieval encountered an error"
             exit 1
           fi
           ls -la release-assets/
@@ -271,6 +275,7 @@ jobs:
     if: >-
       ${{ always() &&
           (github.event_name == 'repository_dispatch' || github.event_name == 'schedule' || github.event_name == 'push') &&
+          needs.build.result == 'failure' &&
           needs.release.result == 'failure' }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Refactor nanvix-ci.yml so that the CI pipeline publishes a release containing only the binaries from matrix configurations that passed testing. The pipeline now fails only when ALL matrix legs fail.

## Changes

- **Download All Artifacts step**: add continue-on-error: true to handle zero artifacts gracefully
- **Prepare Release Assets step**: add asset count check that exits 1 only when zero artifacts exist (all legs failed)
- **report-failure job**: depend on release job and trigger only when release fails (i.e., all matrix legs failed)

## Behavior

| Scenario | Build result | Release runs? | Release result | Failure reported? |
|---|---|---|---|---|
| All 5 legs pass | success | yes | success (5 artifacts) | no |
| 3/5 legs pass | failure | yes | success (3 artifacts) | no |
| 0/5 legs pass | failure | yes | failure (0 artifacts) | yes |
| Workflow cancelled | - | no (cancelled) | skipped | no |

## Safeguards

- fail-fast: false (already present) ensures all matrix legs complete independently
- Upload steps use if: success() (default), so only passing legs produce artifacts
