### PR TITLE
Migrate to nanvix-zutil CLI (ZScript scaffolding + CI rewrite)

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -83,6 +83,16 @@ jobs:
           /tmp/zutil-venv/bin/pip install "$WHEEL_URL"
           ln -sf /tmp/zutil-venv/bin/nanvix-zutil /usr/local/bin/nanvix-zutil
 
+      - name: Prepare libffi sources
+        run: |
+          # The git repo may not have a pre-generated configure script.
+          # Download the release tarball which includes it.
+          if [ ! -f configure ]; then
+            curl -fsSL -o /tmp/libffi-3.4.6.tar.gz https://github.com/libffi/libffi/releases/download/v3.4.6/libffi-3.4.6.tar.gz
+            tar xf /tmp/libffi-3.4.6.tar.gz -C /tmp
+            cp -a /tmp/libffi-3.4.6/* .
+          fi
+
       - name: Setup
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -4,11 +4,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
   push:
-    branches:
-      - nanvix/**
+    branches: ["nanvix/**"]
   pull_request:
-    branches:
-      - nanvix/**
+    branches: ["nanvix/**"]
   workflow_dispatch:
   repository_dispatch:
     types: [nanvix-minor-release, nanvix-major-release]
@@ -24,38 +22,31 @@ concurrency:
 
 jobs:
   get-nanvix-info:
+    name: Get Nanvix Info
     runs-on: ubuntu-latest
     outputs:
-      sha: ${{ steps.extract.outputs.sha }}
-      sha_full: ${{ steps.extract.outputs.sha_full }}
+      nanvix_tag: ${{ steps.resolve.outputs.nanvix_tag }}
+      nanvix_sha: ${{ steps.resolve.outputs.nanvix_sha }}
+      nanvix_version: ${{ steps.resolve.outputs.nanvix_version }}
+      package_name: ${{ steps.resolve.outputs.package_name }}
+      package_version: ${{ steps.resolve.outputs.package_version }}
     steps:
-      - name: Download Nanvix Release Artifacts
-        id: extract
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          # Download all Nanvix release artifacts (authenticated to avoid API rate limits)
-          curl -fsSL https://raw.githubusercontent.com/nanvix/nanvix/refs/heads/dev/scripts/get-nanvix.sh | bash -s -- --force nanvix-artifacts
-          # Find any artifact to extract the SHA
-          ARTIFACT_FILE=$(find nanvix-artifacts -maxdepth 1 -type f -name "*.tar.bz2" | head -1)
-          if [[ -z "$ARTIFACT_FILE" ]]; then
-            echo "::error::No Nanvix artifact found"
-            exit 1
-          fi
-          # Extract Nanvix commit SHA from artifact filename
-          NANVIX_SHA_FULL=$(basename "$ARTIFACT_FILE" | sed -E 's/.*-([a-f0-9]{40})\.tar\.bz2$/\1/')
-          NANVIX_SHA="${NANVIX_SHA_FULL::7}"
-          echo "Nanvix commit SHA: $NANVIX_SHA_FULL (short: $NANVIX_SHA)"
-          echo "sha=$NANVIX_SHA" >> "$GITHUB_OUTPUT"
-          echo "sha_full=$NANVIX_SHA_FULL" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@v5
 
-      - name: Upload Nanvix Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: nanvix-release-artifacts
-          path: nanvix-artifacts/*.tar.bz2
-          retention-days: 1
+      - name: Install nanvix-zutil
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+        run: |
+          WHEEL_URL=$(curl -fsSL -H "Authorization: token $GH_TOKEN" \
+            https://api.github.com/repos/nanvix/zutils/releases/latest \
+            | python3 -c "import json,sys; assets=json.load(sys.stdin)['assets']; print(next(a['browser_download_url'] for a in assets if a['name'].endswith('.whl')))")
+          python3 -m pip install "$WHEEL_URL"
+
+      - name: Resolve lockfile and extract release info
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+        run: nanvix-zutil resolve >> "$GITHUB_OUTPUT"
 
   build:
     needs: get-nanvix-info
@@ -74,162 +65,139 @@ jobs:
       run:
         shell: bash
     env:
-      NANVIX_SHA: ${{ needs.get-nanvix-info.outputs.sha }}
-      NANVIX_SHA_FULL: ${{ needs.get-nanvix-info.outputs.sha_full }}
+      NANVIX_MACHINE: ${{ matrix.platform }}
+      NANVIX_DEPLOYMENT_MODE: ${{ matrix.process-mode }}
+      NANVIX_MEMORY_SIZE: ${{ matrix.memory }}
       USER: runner
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - name: Download Nanvix Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: nanvix-release-artifacts
-          path: nanvix-artifacts
-
-      - name: Extract Nanvix Release
+      - name: Install nanvix-zutil
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
         run: |
-          set -euo pipefail
-          # Find and extract the artifact matching platform and process-mode
-          ARTIFACT_PATTERN="${{ matrix.platform }}.*${{ matrix.process-mode }}.*${{ matrix.memory }}.*\.tar\.bz2"
-          ARTIFACT_FILE=$(find nanvix-artifacts -maxdepth 1 -type f -name "*.tar.bz2" | grep -E "$ARTIFACT_PATTERN" | head -1)
-          if [[ -z "$ARTIFACT_FILE" ]]; then
-            echo "::error::No ${{ matrix.platform }} ${{ matrix.process-mode }} artifact found"
-            exit 1
-          fi
-          mkdir -p nanvix-artifacts/extracted
-          tar -xjf "$ARTIFACT_FILE" -C nanvix-artifacts/extracted
-          NANVIX_HOME=$(find nanvix-artifacts/extracted -maxdepth 2 -type d -name "bin" -exec dirname {} \; | head -1)
-          mkdir -p "$NANVIX_HOME/include"
-          echo "NANVIX_HOME=$NANVIX_HOME" >> "$GITHUB_ENV"
+          python3 -m venv /tmp/zutil-venv
+          WHEEL_URL=$(curl -fsSL -H "Authorization: token $GH_TOKEN" \
+            https://api.github.com/repos/nanvix/zutils/releases/latest \
+            | python3 -c "import json,sys; assets=json.load(sys.stdin)['assets']; print(next(a['browser_download_url'] for a in assets if a['name'].endswith('.whl')))")
+          /tmp/zutil-venv/bin/pip install "$WHEEL_URL"
+          ln -sf /tmp/zutil-venv/bin/nanvix-zutil /usr/local/bin/nanvix-zutil
 
-      - name: Prepare libffi sources
-        run: |
-          # The git submodule may not have a pre-generated configure script.
-          # Download the release tarball which includes it.
-          if [ ! -f configure ]; then
-            curl -fsSL -o /tmp/libffi-3.4.6.tar.gz https://github.com/libffi/libffi/releases/download/v3.4.6/libffi-3.4.6.tar.gz
-            tar xf /tmp/libffi-3.4.6.tar.gz -C /tmp
-            cp -a /tmp/libffi-3.4.6/* .
-          fi
+      - name: Setup
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+        run: nanvix-zutil setup
 
       - name: Build
-        run: |
-          make -f Makefile.nanvix CONFIG_NANVIX=y \
-            NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" \
-            INSTALL_PREFIX="/sysroot" all
+        run: nanvix-zutil build
 
-      - name: Smoke Tests
-        run: |
-          make -f Makefile.nanvix CONFIG_NANVIX=y \
-            NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" test-smoke
-
-      - name: Integration Tests
-        run: |
-          make -f Makefile.nanvix CONFIG_NANVIX=y \
-            NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" test-integration
-
-      - name: Functional Tests
+      - name: Test
         if: matrix.process-mode != 'standalone'
-        run: |
-          timeout --foreground 300 make -f Makefile.nanvix CONFIG_NANVIX=y \
-            NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" \
-            PROCESS_MODE="${{ matrix.process-mode }}" test-functional
+        run: nanvix-zutil test
 
-      - name: Package
-        run: |
-          make -f Makefile.nanvix CONFIG_NANVIX=y \
-            NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" \
-            PLATFORM="${{ matrix.platform }}" PROCESS_MODE="${{ matrix.process-mode }}" \
-            MEMORY_SIZE="${{ matrix.memory }}" \
-            package
-          ARTIFACT_NAME="libffi-${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}"
-          echo "ARTIFACT_TARBALL=dist/${ARTIFACT_NAME}.tar.bz2" >> "$GITHUB_ENV"
+      - name: Test (standalone — smoke + integration only)
+        if: matrix.process-mode == 'standalone'
+        run: nanvix-zutil test -- test-smoke test-integration
 
-      - name: Verify Package
-        run: |
-          make -f Makefile.nanvix CONFIG_NANVIX=y \
-            NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" \
-            PLATFORM="${{ matrix.platform }}" PROCESS_MODE="${{ matrix.process-mode }}" \
-            MEMORY_SIZE="${{ matrix.memory }}" \
-            verify-package
+      - name: Release
+        if: success()
+        run: nanvix-zutil release
 
-      - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v4
+      - name: Upload build artifacts
+        if: success()
+        uses: actions/upload-artifact@v5
         with:
-          name: libffi-${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}
-          path: ${{ env.ARTIFACT_TARBALL }}
+          name: ${{ needs.get-nanvix-info.outputs.package_name }}-${{ needs.get-nanvix-info.outputs.package_version }}-${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}
+          path: dist/*.tar.bz2
           retention-days: 7
+
+      - name: Collect failure logs
+        if: failure()
+        run: |
+          mkdir -p ci-logs
+          cp -f /tmp/*.log ci-logs/ 2>/dev/null || true
+          find .nanvix -type f -name "*.log" -exec cp -f {} ci-logs/ \; 2>/dev/null || true
+
+      - name: Upload failure logs
+        if: failure()
+        uses: actions/upload-artifact@v5
+        with:
+          name: failure-logs-${{ matrix.platform }}-${{ matrix.process-mode }}
+          path: ci-logs/*
+          if-no-files-found: warn
 
   release:
     needs: [get-nanvix-info, build]
     if: ${{ !cancelled() && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
-    env:
-      NANVIX_SHA: ${{ needs.get-nanvix-info.outputs.sha }}
-      NANVIX_SHA_FULL: ${{ needs.get-nanvix-info.outputs.sha_full }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - name: Download All Artifacts
+      - name: Download all build artifacts
         id: download-artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         continue-on-error: true
         with:
           path: release-artifacts
-          pattern: libffi-*
+          pattern: ${{ needs.get-nanvix-info.outputs.package_name }}-${{ needs.get-nanvix-info.outputs.package_version }}-*
 
-      - name: Prepare Release Assets
+      - name: Prepare release assets
         run: |
           set -euo pipefail
           mkdir -p release-assets
           if [[ "${{ steps.download-artifacts.outcome }}" == "failure" ]]; then
-            echo "::warning::Artifact download step failed — this may indicate an API or network issue"
+            echo "::warning::Artifact download failed — possible API or network issue"
           fi
           find release-artifacts -name "*.tar.bz2" -exec cp {} release-assets/ \; 2>/dev/null || true
           ASSET_COUNT=$(find release-assets -name "*.tar.bz2" 2>/dev/null | wc -l)
           echo "Found $ASSET_COUNT release asset(s)"
           if [[ "$ASSET_COUNT" -eq 0 ]]; then
-            echo "::error::No release assets found — all matrix builds may have failed or artifact retrieval encountered an error"
+            echo "::error::No release assets found — all matrix builds may have failed"
             exit 1
           fi
           ls -la release-assets/
 
-      - name: Get Nanvix Release Info
-        id: nanvix-release
+      - name: Generate lockfile
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          API_URL="https://api.github.com/repos/nanvix/nanvix/releases/tags/latest"
-          RELEASE_INFO=$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" "$API_URL")
-          NANVIX_NAME=$(echo "$RELEASE_INFO" | jq -r '.name // "latest"')
-          NANVIX_PUBLISHED=$(echo "$RELEASE_INFO" | jq -r '.published_at')
-          echo "name=${NANVIX_NAME}" >> "$GITHUB_OUTPUT"
-          echo "published=${NANVIX_PUBLISHED}" >> "$GITHUB_OUTPUT"
+          WHEEL_URL=$(curl -fsSL -H "Authorization: token $GH_TOKEN" \
+            https://api.github.com/repos/nanvix/zutils/releases/latest \
+            | python3 -c "import json,sys; assets=json.load(sys.stdin)['assets']; print(next(a['browser_download_url'] for a in assets if a['name'].endswith('.whl')))")
+          python3 -m pip install "$WHEEL_URL"
+          nanvix-zutil resolve > /dev/null
+          nanvix-zutil lock --shallow
+          cp .nanvix/nanvix.lock release-assets/nanvix.lock
 
-      - name: Create Latest Release
+      - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NANVIX_NAME: ${{ steps.nanvix-release.outputs.name }}
-          NANVIX_PUBLISHED: ${{ steps.nanvix-release.outputs.published }}
+          NANVIX_VERSION: ${{ needs.get-nanvix-info.outputs.nanvix_version }}
+          NANVIX_SHA: ${{ needs.get-nanvix-info.outputs.nanvix_sha }}
+          LIBFFI_VERSION: ${{ needs.get-nanvix-info.outputs.package_version }}
         run: |
-          RELEASE_TAG="${GITHUB_SHA::7}-nanvix-${NANVIX_SHA}"
-          if gh release view "$RELEASE_TAG" &>/dev/null; then
-            gh release delete "$RELEASE_TAG" --yes --cleanup-tag || true
+          SEMVER_TAG="${LIBFFI_VERSION}-nanvix-${NANVIX_VERSION}"
+          COMMITISH_TAG="${LIBFFI_VERSION}-nanvix-${NANVIX_SHA}"
+
+          # Idempotency: skip if release already exists.
+          if gh release view "$SEMVER_TAG" &>/dev/null; then
+            echo "Release $SEMVER_TAG already exists; skipping."
+            exit 0
           fi
-          gh release create "$RELEASE_TAG" \
-            --title "Build ${GITHUB_SHA::7}" \
+
+          gh release create "$SEMVER_TAG" \
+            --title "libffi ${LIBFFI_VERSION} for Nanvix ${NANVIX_VERSION}" \
             --notes "Automated build from branch ${{ github.ref_name }} at commit ${{ github.sha }}.
 
           **Build Information:**
           - Workflow Run: [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
           - Commit: [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
-          - Date: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+          - Date: $(date -u +'%Y-%m-%d %H:%M:%S UTC')
 
           **Nanvix Release:**
-          - Name: ${NANVIX_NAME}
-          - Published: ${NANVIX_PUBLISHED}
-          - Commit: [${NANVIX_SHA_FULL}](https://github.com/nanvix/nanvix/commit/${NANVIX_SHA_FULL})
+          - Version: ${NANVIX_VERSION}
+          - Commit: [${NANVIX_SHA}](https://github.com/nanvix/nanvix/commit/${NANVIX_SHA})
 
           **Package Layout:**
           \`\`\`
@@ -239,37 +207,47 @@ jobs:
             bin/ffi_test.elf
           \`\`\`
 
-          **Dependencies:** None (standalone library)" \
+          **Dependencies:** None (standalone library)
+          **Lockfile:** nanvix.lock included for downstream dependency resolution" \
             --latest \
-            release-assets/*.tar.bz2
+            release-assets/*.tar.bz2 \
+            release-assets/nanvix.lock
 
-      - name: Trigger Dependent Workflows
+          # Create secondary commitish tag.
+          git tag -f "$COMMITISH_TAG"
+          git push -f origin "refs/tags/$COMMITISH_TAG"
+
+      - name: Trigger dependent workflows
         if: success()
         env:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+          NANVIX_VERSION: ${{ needs.get-nanvix-info.outputs.nanvix_version }}
+          NANVIX_SHA: ${{ needs.get-nanvix-info.outputs.nanvix_sha }}
+          LIBFFI_VERSION: ${{ needs.get-nanvix-info.outputs.package_version }}
         run: |
-          RELEASE_TAG="${GITHUB_SHA::7}-nanvix-${NANVIX_SHA}"
+          SEMVER_TAG="${LIBFFI_VERSION}-nanvix-${NANVIX_VERSION}"
           echo "Triggering cpython workflow..."
           gh api repos/nanvix/cpython/dispatches \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -f event_type="libffi-release" \
             -f "client_payload[nanvix_sha]=${NANVIX_SHA}" \
-            -f "client_payload[libffi_tag]=${RELEASE_TAG}" || echo "::warning::Failed to trigger cpython workflow"
+            -f "client_payload[nanvix_version]=${NANVIX_VERSION}" \
+            -f "client_payload[libffi_tag]=${SEMVER_TAG}" || echo "::warning::Failed to trigger cpython workflow"
 
   report-failure:
     needs: [build, release]
     if: >-
       ${{ always() &&
-          (github.event_name == 'repository_dispatch' || github.event_name == 'schedule' || github.event_name == 'push') &&
-          needs.build.result == 'failure' &&
-          needs.release.result == 'failure' }}
+          (github.event_name == 'push' ||
+           github.event_name == 'schedule' ||
+           github.event_name == 'repository_dispatch') &&
+          (needs.build.result == 'failure' ||
+           needs.release.result == 'failure') }}
     runs-on: ubuntu-latest
     steps:
       - name: Report failure issue
-        uses: actions/github-script@v7
-        env:
-          BUILD_RESULT: ${{ needs.build.result }}
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -278,13 +256,12 @@ jobs:
             const repo = context.repo.repo;
             const title = `CI failure`;
             const body = [
-              `The libffi CI workflow failed.`,
+              `CI workflow failed.`,
               `- Trigger: ${context.eventName}`,
               `- Run: [#${context.runNumber}](${runUrl})`,
               `- SHA: ${context.sha}`,
-              `- build: ${process.env.BUILD_RESULT}`,
               '',
-              'Please investigate and take any corrective actions.'
+              'Please investigate and take corrective action.'
             ].join('\n');
 
             const { data: search } = await github.rest.search.issuesAndPullRequests({
@@ -293,13 +270,21 @@ jobs:
             const existing = search.items.find(i => i.title === title);
 
             if (existing) {
-              await github.rest.issues.createComment({ owner, repo, issue_number: existing.number, body });
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: existing.number, body
+              });
+              // Reconcile assignees: add any missing desired assignees.
               const currentAssignees = existing.assignees.map(a => a.login);
               const desired = ['ppenna', 'danbugs'];
               const missing = desired.filter(a => !currentAssignees.includes(a));
               if (missing.length > 0) {
-                await github.rest.issues.addAssignees({ owner, repo, issue_number: existing.number, assignees: missing });
+                await github.rest.issues.addAssignees({
+                  owner, repo, issue_number: existing.number, assignees: missing
+                });
               }
             } else {
-              await github.rest.issues.create({ owner, repo, title, body, assignees: ['ppenna', 'danbugs'] });
+              await github.rest.issues.create({
+                owner, repo, title, body, assignees: ['ppenna', 'danbugs']
+              });
             }
+

--- a/.github/workflows/prune-releases.yml
+++ b/.github/workflows/prune-releases.yml
@@ -1,0 +1,94 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# ==========================================================================
+# Release Retention Workflow
+#
+# Deletes CI-generated releases older than 90 days.
+#
+# Releases with tags NOT matching the CI pattern
+# ({version}-nanvix-{nanvix_version}) are preserved — use non-matching
+# tags for milestone releases you want to keep.
+# ==========================================================================
+
+name: Prune Old Releases
+
+on:
+  schedule:
+    # Run every Sunday at 04:00 UTC.
+    # Off-peak hour to reduce rate-limit contention.
+    - cron: "0 4 * * 0"
+  workflow_dispatch:
+
+jobs:
+  prune:
+    name: Prune Releases Older Than 90 Days
+    # Guard: only run in nanvix/libffi to prevent accidental reuse in forks.
+    if: github.repository == 'nanvix/libffi'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+
+    steps:
+      - name: Delete expired CI releases
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const RETENTION_DAYS = 90;
+            const MS_PER_DAY = 24 * 60 * 60 * 1000;
+            const cutoff = new Date();
+            cutoff.setDate(cutoff.getDate() - RETENTION_DAYS);
+
+            // Match CI-generated tags:
+            //   semver:    {version}-nanvix-{nanvix_version}  e.g. 3.4.6-nanvix-0.12.267
+            //   commitish: {version}-nanvix-{sha7}            e.g. 3.4.6-nanvix-abc1234
+            const ciTagRe = /^\d+\.\d+\.\d+-nanvix-(\d+\.\d+\.\d+|[0-9a-f]{7})$/;
+
+            const releases = await github.paginate(
+              github.rest.repos.listReleases,
+              { owner, repo, per_page: 100 }
+            );
+
+            let deleted = 0;
+            for (const rel of releases) {
+              if (rel.draft) continue;
+
+              // Only prune CI-generated releases — preserve everything else
+              if (!ciTagRe.test(rel.tag_name)) continue;
+
+              // Use published_at for age/cutoff when available, falling back to created_at.
+              const effectiveDate = rel.published_at
+                ? new Date(rel.published_at)
+                : new Date(rel.created_at);
+              if (effectiveDate >= cutoff) continue;
+
+              const ageDays = Math.floor((Date.now() - effectiveDate) / MS_PER_DAY);
+              core.info(
+                `Deleting ${rel.tag_name} (effective date ${effectiveDate.toISOString()}, age ${ageDays}d).`
+              );
+
+              try {
+                await github.rest.repos.deleteRelease({
+                  owner, repo, release_id: rel.id,
+                });
+              } catch (error) {
+                if (error.status !== 404 && error.status !== 422) throw error;
+                core.info(`Release ${rel.tag_name} already deleted.`);
+              }
+
+              // Best-effort tag cleanup — log failures without halting.
+              try {
+                await github.rest.git.deleteRef({
+                  owner, repo, ref: `tags/${rel.tag_name}`,
+                });
+              } catch (error) {
+                core.warning(`Failed to delete tag ${rel.tag_name}: ${error.message}`);
+              }
+
+              deleted++;
+            }
+
+            core.info(`Pruned ${deleted} release(s) older than ${RETENTION_DAYS} days.`);

--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,0 +1,6 @@
+manifest-version = "0.1.0"
+
+[package]
+name = "libffi"
+version = "3.4.6"
+nanvix-version = "latest"

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -3,7 +3,15 @@
 
 """Nanvix build script for libffi."""
 
-from nanvix_zutil import CFG_SYSROOT, CFG_TOOLCHAIN, EXIT_BUILD_FAILURE, ZScript, log
+from nanvix_zutil import CFG_SYSROOT, CFG_TOOLCHAIN, EXIT_MISSING_DEP, ZScript, log
+
+# Makefile variable names (build-system-specific).
+_MAKE_VAR_CONFIG = "CONFIG_NANVIX"
+_MAKE_VAR_HOME = "NANVIX_HOME"
+_MAKE_VAR_TOOLCHAIN = "NANVIX_TOOLCHAIN"
+_MAKE_VAR_PLATFORM = "PLATFORM"
+_MAKE_VAR_PROCESS_MODE = "PROCESS_MODE"
+_MAKE_VAR_MEMORY_SIZE = "MEMORY_SIZE"
 
 
 class LibffiBuild(ZScript):
@@ -14,40 +22,45 @@ class LibffiBuild(ZScript):
         sysroot = self.config.get(CFG_SYSROOT, "")
         if not sysroot:
             log.fatal(
-                "Sysroot not configured — run 'nanvix-zutil setup' first.",
-                code=EXIT_BUILD_FAILURE,
+                f"{CFG_SYSROOT} is not set.",
+                code=EXIT_MISSING_DEP,
+                hint="Run `./z setup` first to download the sysroot.",
             )
-        toolchain = self.config.get(CFG_TOOLCHAIN, "/opt/nanvix") or "/opt/nanvix"
+        toolchain = self.config.get(CFG_TOOLCHAIN, "/opt/nanvix")
 
         args = [
             "make", "-f", "Makefile.nanvix",
-            "CONFIG_NANVIX=y",
-            f"NANVIX_HOME={sysroot}",
-            f"NANVIX_TOOLCHAIN={toolchain}",
-            f"PLATFORM={self.config.machine}",
-            f"PROCESS_MODE={self.config.deployment_mode}",
-            f"MEMORY_SIZE={self.config.memory_size}",
+            f"{_MAKE_VAR_CONFIG}=y",
+            f"{_MAKE_VAR_HOME}={sysroot}",
+            f"{_MAKE_VAR_TOOLCHAIN}={toolchain}",
         ]
+
+        args.extend([
+            f"{_MAKE_VAR_PLATFORM}={self.config.machine}",
+            f"{_MAKE_VAR_PROCESS_MODE}={self.config.deployment_mode}",
+            f"{_MAKE_VAR_MEMORY_SIZE}={self.config.memory_size}",
+        ])
+
         args.extend(targets)
         return args
 
     def build(self) -> None:
         """Cross-compile libffi.a for Nanvix."""
-        self.run(*self._make_args("all"))
+        self.run(*self._make_args("all"), cwd=self.repo_root)
 
     def test(self) -> None:
         """Run the libffi test suite."""
         targets = self.targets if self.targets else ["test"]
-        self.run(*self._make_args(*targets))
+        self.run(*self._make_args(*targets), cwd=self.repo_root)
 
     def release(self) -> None:
         """Package the libffi release tarball and verify it."""
-        self.run(*self._make_args("package"))
-        self.run(*self._make_args("verify-package"))
+        self.run(*self._make_args("package"), cwd=self.repo_root)
+        self.run(*self._make_args("verify-package"), cwd=self.repo_root)
 
     def clean(self) -> None:
         """Remove build artifacts."""
-        self.run("make", "-f", "Makefile.nanvix", "clean")
+        self.run("make", "-f", "Makefile.nanvix", "clean", cwd=self.repo_root)
 
 
 if __name__ == "__main__":

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -1,0 +1,54 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""Nanvix build script for libffi."""
+
+from nanvix_zutil import CFG_SYSROOT, CFG_TOOLCHAIN, EXIT_BUILD_FAILURE, ZScript, log
+
+
+class LibffiBuild(ZScript):
+    """Build script for nanvix/libffi."""
+
+    def _make_args(self, *targets: str) -> list[str]:
+        """Build the common make argument list."""
+        sysroot = self.config.get(CFG_SYSROOT, "")
+        if not sysroot:
+            log.fatal(
+                "Sysroot not configured — run 'nanvix-zutil setup' first.",
+                code=EXIT_BUILD_FAILURE,
+            )
+        toolchain = self.config.get(CFG_TOOLCHAIN, "/opt/nanvix") or "/opt/nanvix"
+
+        args = [
+            "make", "-f", "Makefile.nanvix",
+            "CONFIG_NANVIX=y",
+            f"NANVIX_HOME={sysroot}",
+            f"NANVIX_TOOLCHAIN={toolchain}",
+            f"PLATFORM={self.config.machine}",
+            f"PROCESS_MODE={self.config.deployment_mode}",
+            f"MEMORY_SIZE={self.config.memory_size}",
+        ]
+        args.extend(targets)
+        return args
+
+    def build(self) -> None:
+        """Cross-compile libffi.a for Nanvix."""
+        self.run(*self._make_args("all"))
+
+    def test(self) -> None:
+        """Run the libffi test suite."""
+        targets = self.targets if self.targets else ["test"]
+        self.run(*self._make_args(*targets))
+
+    def release(self) -> None:
+        """Package the libffi release tarball and verify it."""
+        self.run(*self._make_args("package"))
+        self.run(*self._make_args("verify-package"))
+
+    def clean(self) -> None:
+        """Remove build artifacts."""
+        self.run("make", "-f", "Makefile.nanvix", "clean")
+
+
+if __name__ == "__main__":
+    LibffiBuild.main()

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -24,7 +24,7 @@ class LibffiBuild(ZScript):
             log.fatal(
                 f"{CFG_SYSROOT} is not set.",
                 code=EXIT_MISSING_DEP,
-                hint="Run `./z setup` first to download the sysroot.",
+                hint="Run `nanvix-zutil setup` first to download the sysroot.",
             )
         toolchain = self.config.get(CFG_TOOLCHAIN, "/opt/nanvix")
 


### PR DESCRIPTION
## Summary

Migrate libffi to the `nanvix-zutil` CLI framework, matching the pattern landed in nanvix/zlib#33. This is the only repo that had **no prior ZScript infrastructure** — everything is created from scratch.

### What changed

**ZScript scaffolding (Commit 1):**
- Create `.nanvix/` directory (did not exist)
- Create `.nanvix/nanvix.toml` manifest (version `3.4.6` from `configure.ac`)
- Create `.nanvix/z.py` using the Makefile delegation pattern
- `Makefile.nanvix` is **preserved unchanged** — `z.py` delegates to it

**CI rewrite (Commit 2):**
- Rewrite `nanvix-ci.yml` from scratch based on the landed zlib CI
- `get-nanvix-info`: `nanvix-zutil resolve` replaces inline bash
- `build`: matrix (platform × process-mode × memory), nanvix-zutil CLI for setup/build/test/release
- **Upstream tarball fallback preserved:** The git repo does not include a pre-generated `configure` script. The old CI step that downloads `libffi-3.4.6.tar.gz` from upstream when `configure` is missing has been kept. This is needed because the repo is a fork of the git repo, not the release tarball.
- `release`: semver tags, idempotency guards, lockfile generation, dispatch `libffi-release` to cpython
- `report-failure`: dedup logic, assignees `[ppenna, danbugs]` (matching existing CI)
- Add `prune-releases.yml` for 90-day release retention

### Design decisions

- **Upstream tarball fallback kept (intentional):** The schematic originally said to remove this, but the repo fork genuinely does not have `configure`. Without the fallback, the build job would fail with `./configure: not found`. The long-term fix is to either commit the generated configure script or switch to the release tarball as the repo source.
- **`EXIT_MISSING_DEP` exit code:** Missing sysroot → dependency error, not build failure.
- **`cwd=self.repo_root`:** Defensive, ensures make finds `Makefile.nanvix` regardless of working directory.
- **`_MAKE_VAR_*` constants:** Makefile variable names defined once at module level.
- **Dual assignees `[ppenna, danbugs]`:** Matches the existing libffi CI (the only repo with dual assignees). Other repos use `[ppenna]` only.

### Reference

All patterns from the landed zlib migration: nanvix/zlib#33 (CI green).
