### PR TITLE
[ci] Update nanvix-ci workflow to v1.2.0

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.0.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.2.0
     with:
       zutil-version: "v0.4.0"
       caller-event-name: ${{ github.event_name }}


### PR DESCRIPTION
Bump the reusable nanvix-ci workflow reference from v1.0.0 to v1.2.0.

Key changes in v1.2.0:
- Add `matrix-exclude` input for flexible build matrix filtering
- Add `report-failure` job to open GitHub issues on scheduled-run failures
- Require `GH_TOKEN` secret (was optional)