### PR TITLE
[ci] E: Clean up nanvix-ci workflow

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -11,8 +11,6 @@ on:
   pull_request:
     branches: ["nanvix/**"]
   workflow_dispatch:
-  repository_dispatch:
-    types: [nanvix-minor-release, nanvix-major-release]
 
 permissions:
   contents: write
@@ -21,7 +19,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name || github.ref || 'default' }}
-  cancel-in-progress: ${{ github.event_name == 'repository_dispatch' }}
+  cancel-in-progress: true
 
 jobs:
   ci:

--- a/NANVIX.md
+++ b/NANVIX.md
@@ -259,7 +259,6 @@ shared CI configuration and are not defined directly in this repository's workfl
 | PR to `nanvix/**` | Pull requests targeting Nanvix branches |
 | Daily schedule | Runs at midnight UTC |
 | Manual dispatch | Can be triggered manually |
-| Repository dispatch | Triggered by `nanvix-minor-release` or `nanvix-major-release` events |
 
 ### Build Matrix
 


### PR DESCRIPTION
## Summary

Clean up the nanvix-ci workflow configuration:

- Remove unused `repository_dispatch` trigger
- Set `cancel-in-progress` to `true` unconditionally
- Fix trailing blank lines