### PR TITLE
fix/bootstrap

### DIFF
--- a/.nanvix/.gitignore
+++ b/.nanvix/.gitignore
@@ -1,0 +1,7 @@
+venv/
+cache/
+sysroot/
+buildroot/
+env.json
+nanvix.lock
+__pycache__

--- a/z
+++ b/z
@@ -11,7 +11,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 case "$(uname -s)" in
     CYGWIN*|MINGW*|MSYS*)
-        exec powershell.exe -NoProfile \
+        exec powershell.exe -NoProfile -ExecutionPolicy Bypass \
             -File "$SCRIPT_DIR/z.ps1" "$@"
         ;;
     *)

--- a/z.ps1
+++ b/z.ps1
@@ -2,52 +2,78 @@
 # Licensed under the MIT License.
 
 # Thin wrapper that delegates to the nanvix-zutil CLI.
-# Requires nanvix-zutil to be installed (pip install nanvix-zutil).
+# Self-bootstraps nanvix-zutil into .nanvix\venv\ if it is not already installed.
 
 param(
     [Parameter(ValueFromRemainingArguments = $true)]
-    [string[]]$Args
+    [string[]]$ZArgs
 )
 
 $ErrorActionPreference = 'Stop'
 
-# If nanvix-zutil is already on PATH (e.g. CI), use it directly.
-if (Get-Command nanvix-zutil -ErrorAction SilentlyContinue) {
-    & nanvix-zutil @Args
-    exit $LASTEXITCODE
+$zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
+    $env:NANVIX_ZUTIL_VERSION
+}
+else {
+    "0.5.0"
 }
 
-$repoRoot = git rev-parse --show-toplevel
+# z.ps1 lives at the repository root, so use its directory directly
+# instead of relying on git to discover the top-level checkout directory.
+$repoRoot = $PSScriptRoot
 $venvDir = Join-Path $repoRoot ".nanvix\venv"
 $venvPython = Join-Path $venvDir "Scripts\python.exe"
 $venvZutil = Join-Path $venvDir "Scripts\nanvix-zutil.exe"
+$zutilGlobalVersion = try {
+    & nanvix-zutil --version 2>$null
+}
+catch {
+    $null
+}
 
-if (-not (Test-Path $venvZutil) -and -not (Get-Command nanvix-zutil -ErrorAction SilentlyContinue)) {
-    Write-Host "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." -ForegroundColor Yellow
-    $release = Invoke-RestMethod "https://api.github.com/repos/nanvix/zutils/releases/latest"
-    $wheelUrl = ($release.assets | Where-Object { $_.name -like "*.whl" } | Select-Object -First 1).browser_download_url
-    if (-not $wheelUrl) {
-        throw "No .whl asset found in latest nanvix/zutils release. Install manually: pip install nanvix-zutil"
-    }
-    # Discover a Python 3 interpreter
+function Bootstrap {
+    # Pin nanvix-zutil version for reproducible bootstrapping.
+    # Override with NANVIX_ZUTIL_VERSION env var if needed.
+    Write-Host "nanvix-zutil not found — bootstrapping nanvix-zutil==${zutilVersion}..." -ForegroundColor Yellow
+
+    $wheelUrl = "https://github.com/nanvix/zutils/releases/download/v${zutilVersion}/nanvix_zutil-${zutilVersion}-py3-none-any.whl"
+
+    # Discover a Python 3 interpreter.
     if (Get-Command py -ErrorAction SilentlyContinue) {
         & py -3 -m venv $venvDir
-    } elseif (Get-Command python -ErrorAction SilentlyContinue) {
+    }
+    elseif (Get-Command python -ErrorAction SilentlyContinue) {
         & python -m venv $venvDir
-    } elseif (Get-Command python3 -ErrorAction SilentlyContinue) {
+    }
+    elseif (Get-Command python3 -ErrorAction SilentlyContinue) {
         & python3 -m venv $venvDir
-    } else {
+    }
+    else {
         throw "Python 3 not found. Install Python 3 and ensure py, python, or python3 is on PATH."
     }
     & $venvPython -m pip install --quiet $wheelUrl
 }
 
-# Prefer the venv copy; fall back to global.
-if (Test-Path $venvZutil) {
-    & $venvZutil @Args
-} elseif (Get-Command nanvix-zutil -ErrorAction SilentlyContinue) {
-    & nanvix-zutil @Args
-} else {
-    throw "nanvix-zutil not found in venv ($venvDir) or on PATH."
+# Prefer the venv copy if it exists; otherwise use the global install.
+$bin = $null
+if ((-not (Test-Path $venvDir)) -and (-not $zutilGlobalVersion)) {
+    Bootstrap
+    $bin = $venvZutil
 }
+elseif (Test-Path $venvZutil) {
+    $bin = $venvZutil
+}
+elseif ((Test-Path $venvDir) -and (-not $zutilGlobalVersion)) {
+    Write-Warning "Incomplete venv detected (binary missing). Re-running bootstrap..."
+    Bootstrap
+    $bin = $venvZutil
+}
+else {
+    $bin = "nanvix-zutil"
+    if ($zutilGlobalVersion -ne "nanvix-zutil ${zutilVersion}") {
+        Write-Warning "nanvix-zutil global install does not match expected version. Expected ${zutilVersion}, found ${zutilGlobalVersion}."
+    }
+}
+
+& $bin @ZArgs
 exit $LASTEXITCODE

--- a/z.ps1
+++ b/z.ps1
@@ -14,7 +14,6 @@ $ErrorActionPreference = 'Stop'
 $repoRoot = git rev-parse --show-toplevel
 $venvDir = Join-Path $repoRoot ".nanvix\venv"
 $venvPython = Join-Path $venvDir "Scripts\python.exe"
-$venvActivate = Join-Path $venvDir "Scripts\Activate.ps1"
 $venvZutil = Join-Path $venvDir "Scripts\nanvix-zutil.exe"
 
 if (-not (Test-Path $venvZutil) -and -not (Get-Command nanvix-zutil -ErrorAction SilentlyContinue)) {
@@ -39,8 +38,7 @@ if (-not (Test-Path $venvZutil) -and -not (Get-Command nanvix-zutil -ErrorAction
 
 # Prefer the venv copy; fall back to global.
 if (Test-Path $venvZutil) {
-    if (Test-Path $venvActivate) { & $venvActivate }
-    & nanvix-zutil @Args
+    & $venvZutil @Args
 } elseif (Get-Command nanvix-zutil -ErrorAction SilentlyContinue) {
     & nanvix-zutil @Args
 } else {

--- a/z.ps1
+++ b/z.ps1
@@ -11,5 +11,20 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+$repoRoot = git rev-parse --show-toplevel
+$venvPython = Join-Path $repoRoot ".nanvix\venv\Scripts\python.exe"
+$venvActivate = Join-Path $repoRoot ".nanvix\venv\Scripts\Activate.ps1"
+
+if (-not (Get-Command nanvix-zutil -ErrorAction SilentlyContinue)) {
+    if (-not (Test-Path $venvPython)) {
+        Write-Host "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." -ForegroundColor Yellow
+        $release = Invoke-RestMethod "https://api.github.com/repos/nanvix/zutils/releases/latest"
+        $wheelUrl = ($release.assets | Where-Object { $_.name -like "*.whl" } | Select-Object -First 1).browser_download_url
+        python3 -m venv (Join-Path $repoRoot ".nanvix\venv")
+        & $venvPython -m pip install --quiet $wheelUrl
+    }
+    if (Test-Path $venvActivate) { & $venvActivate }
+}
+
 & nanvix-zutil @Args
 exit $LASTEXITCODE

--- a/z.ps1
+++ b/z.ps1
@@ -11,6 +11,12 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+# If nanvix-zutil is already on PATH (e.g. CI), use it directly.
+if (Get-Command nanvix-zutil -ErrorAction SilentlyContinue) {
+    & nanvix-zutil @Args
+    exit $LASTEXITCODE
+}
+
 $repoRoot = git rev-parse --show-toplevel
 $venvDir = Join-Path $repoRoot ".nanvix\venv"
 $venvPython = Join-Path $venvDir "Scripts\python.exe"

--- a/z.ps1
+++ b/z.ps1
@@ -12,19 +12,38 @@ param(
 $ErrorActionPreference = 'Stop'
 
 $repoRoot = git rev-parse --show-toplevel
-$venvPython = Join-Path $repoRoot ".nanvix\venv\Scripts\python.exe"
-$venvActivate = Join-Path $repoRoot ".nanvix\venv\Scripts\Activate.ps1"
+$venvDir = Join-Path $repoRoot ".nanvix\venv"
+$venvPython = Join-Path $venvDir "Scripts\python.exe"
+$venvActivate = Join-Path $venvDir "Scripts\Activate.ps1"
+$venvZutil = Join-Path $venvDir "Scripts\nanvix-zutil.exe"
 
-if (-not (Get-Command nanvix-zutil -ErrorAction SilentlyContinue)) {
-    if (-not (Test-Path $venvPython)) {
-        Write-Host "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." -ForegroundColor Yellow
-        $release = Invoke-RestMethod "https://api.github.com/repos/nanvix/zutils/releases/latest"
-        $wheelUrl = ($release.assets | Where-Object { $_.name -like "*.whl" } | Select-Object -First 1).browser_download_url
-        python3 -m venv (Join-Path $repoRoot ".nanvix\venv")
-        & $venvPython -m pip install --quiet $wheelUrl
+if (-not (Test-Path $venvZutil) -and -not (Get-Command nanvix-zutil -ErrorAction SilentlyContinue)) {
+    Write-Host "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." -ForegroundColor Yellow
+    $release = Invoke-RestMethod "https://api.github.com/repos/nanvix/zutils/releases/latest"
+    $wheelUrl = ($release.assets | Where-Object { $_.name -like "*.whl" } | Select-Object -First 1).browser_download_url
+    if (-not $wheelUrl) {
+        throw "No .whl asset found in latest nanvix/zutils release. Install manually: pip install nanvix-zutil"
     }
-    if (Test-Path $venvActivate) { & $venvActivate }
+    # Discover a Python 3 interpreter
+    if (Get-Command py -ErrorAction SilentlyContinue) {
+        & py -3 -m venv $venvDir
+    } elseif (Get-Command python -ErrorAction SilentlyContinue) {
+        & python -m venv $venvDir
+    } elseif (Get-Command python3 -ErrorAction SilentlyContinue) {
+        & python3 -m venv $venvDir
+    } else {
+        throw "Python 3 not found. Install Python 3 and ensure py, python, or python3 is on PATH."
+    }
+    & $venvPython -m pip install --quiet $wheelUrl
 }
 
-& nanvix-zutil @Args
+# Prefer the venv copy; fall back to global.
+if (Test-Path $venvZutil) {
+    if (Test-Path $venvActivate) { & $venvActivate }
+    & nanvix-zutil @Args
+} elseif (Get-Command nanvix-zutil -ErrorAction SilentlyContinue) {
+    & nanvix-zutil @Args
+} else {
+    throw "nanvix-zutil not found in venv ($venvDir) or on PATH."
+}
 exit $LASTEXITCODE

--- a/z.sh
+++ b/z.sh
@@ -7,6 +7,11 @@
 
 set -euo pipefail
 
+# If nanvix-zutil is already on PATH (e.g. CI), use it directly.
+if command -v nanvix-zutil &>/dev/null; then
+	exec nanvix-zutil "$@"
+fi
+
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
 REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
 
@@ -29,7 +34,11 @@ if not wheel:
     sys.exit(1)
 print(wheel)
 ")
-	python3 -m venv "$VENV"
+	if [ -d "$VENV" ]; then
+		python3 -m venv --clear "$VENV"
+	else
+		python3 -m venv "$VENV"
+	fi
 	"$VENV/bin/pip" install --quiet "$WHEEL_URL"
 fi
 

--- a/z.sh
+++ b/z.sh
@@ -3,51 +3,51 @@
 # Licensed under the MIT License.
 
 # Thin wrapper that delegates to the nanvix-zutil CLI.
-# Requires nanvix-zutil to be installed (pip install nanvix-zutil).
+# Self-bootstraps nanvix-zutil into .nanvix/venv/ if it is not already installed.
 
 set -euo pipefail
 
-# If nanvix-zutil is already on PATH (e.g. CI), use it directly.
-if command -v nanvix-zutil &>/dev/null; then
-	exec nanvix-zutil "$@"
-fi
-
-SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
-REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
-
+ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-0.5.0}"
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
 VENV="$REPO_ROOT/.nanvix/venv"
+VENV_BIN="$VENV/bin/nanvix-zutil"
+ZUTIL_GLOBAL_VERSION="$(nanvix-zutil --version 2>/dev/null || true )"
 
-if ! "$VENV/bin/nanvix-zutil" --version &>/dev/null && ! command -v nanvix-zutil &>/dev/null; then
-	echo "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." >&2
-	WHEEL_URL=$(curl -fsSL "https://api.github.com/repos/nanvix/zutils/releases/latest" |
-		python3 -c "
-import sys, json
-data = json.load(sys.stdin)
-assets = data.get('assets') or []
-wheel = next(
-    (a['browser_download_url'] for a in assets if a.get('name', '').endswith('.whl')),
-    None,
-)
-if not wheel:
-    print('Error: no .whl asset in latest nanvix/zutils release.', file=sys.stderr)
-    print('Install manually: pip install nanvix-zutil', file=sys.stderr)
-    sys.exit(1)
-print(wheel)
-")
+function bootstrap() {
+	# Pin nanvix-zutil version for reproducible bootstrapping.
+	# Override with NANVIX_ZUTIL_VERSION env var if needed.
+	echo "nanvix-zutil not found — bootstrapping nanvix-zutil==${ZUTIL_VERSION}..." >&2
+
+	if ! command -v python3 &>/dev/null; then
+		echo "Error: python3 not found. Install Python 3 and ensure python3 is on PATH." >&2
+		exit 1
+	fi
+
+	WHEEL_URL="https://github.com/nanvix/zutils/releases/download/v${ZUTIL_VERSION}/nanvix_zutil-${ZUTIL_VERSION}-py3-none-any.whl"
 	if [ -d "$VENV" ]; then
 		python3 -m venv --clear "$VENV"
 	else
 		python3 -m venv "$VENV"
 	fi
 	"$VENV/bin/pip" install --quiet "$WHEEL_URL"
-fi
+}
 
 # Prefer the venv copy if it exists; otherwise use the global install.
-if [ -x "$VENV/bin/nanvix-zutil" ]; then
-	exec "$VENV/bin/nanvix-zutil" "$@"
-elif command -v nanvix-zutil &>/dev/null; then
-	exec nanvix-zutil "$@"
+BIN=""
+if [ ! -d "$VENV" ] && [ -z "$ZUTIL_GLOBAL_VERSION" ]; then
+    bootstrap
+    BIN="$VENV_BIN"
+elif [ -x "$VENV_BIN" ]; then
+    BIN="$VENV_BIN"
+elif [ -d "$VENV" ] && ! command -v nanvix-zutil &>/dev/null; then
+    echo "Warning: incomplete venv detected (binary missing). Re-running bootstrap..." >&2
+    bootstrap
+    BIN="$VENV_BIN"
 else
-	echo "nanvix-zutil not found in venv ($VENV) or on PATH." >&2
-	exit 1
+    BIN="nanvix-zutil"
+    if [ "$ZUTIL_GLOBAL_VERSION" != "nanvix-zutil ${ZUTIL_VERSION}" ]; then
+        echo "Warning: nanvix-zutil global install does not match expected version. Expected ${ZUTIL_VERSION}, found ${ZUTIL_GLOBAL_VERSION}." >&2
+    fi
 fi
+
+exec "$BIN" "$@"

--- a/z.sh
+++ b/z.sh
@@ -7,36 +7,46 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
+
 # In CI containers the checkout directory may be owned by a different uid than
 # the process running this script, triggering git's "dubious ownership" check.
-# Mark the current directory safe before calling git rev-parse.
+# Scope the safe.directory override to this single git invocation.
 if [ -n "${CI:-}" ]; then
-	git config --global --add safe.directory "$(pwd)"
+	REPO_ROOT="$(git -c safe.directory="$SCRIPT_DIR" -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+else
+	REPO_ROOT="$(git rev-parse --show-toplevel)"
 fi
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
 VENV="$REPO_ROOT/.nanvix/venv"
 
-if ! "$VENV/bin/nanvix-zutil" --version &>/dev/null 2>&1 && ! command -v nanvix-zutil &>/dev/null; then
+if ! "$VENV/bin/nanvix-zutil" --version &>/dev/null && ! command -v nanvix-zutil &>/dev/null; then
 	echo "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." >&2
 	WHEEL_URL=$(curl -fsSL "https://api.github.com/repos/nanvix/zutils/releases/latest" |
 		python3 -c "
 import sys, json
 data = json.load(sys.stdin)
+assets = data.get('assets') or []
 wheel = next(
-    a['browser_download_url']
-    for a in data['assets']
-    if a['name'].endswith('.whl')
+    (a['browser_download_url'] for a in assets if a.get('name', '').endswith('.whl')),
+    None,
 )
+if not wheel:
+    print('Error: no .whl asset in latest nanvix/zutils release.', file=sys.stderr)
+    print('Install manually: pip install nanvix-zutil', file=sys.stderr)
+    sys.exit(1)
 print(wheel)
 ")
 	python3 -m venv "$VENV"
 	"$VENV/bin/pip" install --quiet "$WHEEL_URL"
 fi
 
-if [ -f "$VENV/bin/activate" ]; then
-	# shellcheck source=/dev/null
-	source "$VENV/bin/activate"
+# Prefer the venv copy if it exists; otherwise use the global install.
+if [ -x "$VENV/bin/nanvix-zutil" ]; then
+	exec "$VENV/bin/nanvix-zutil" "$@"
+elif command -v nanvix-zutil &>/dev/null; then
+	exec nanvix-zutil "$@"
+else
+	echo "nanvix-zutil not found in venv ($VENV) or on PATH." >&2
+	exit 1
 fi
-
-exec nanvix-zutil "$@"

--- a/z.sh
+++ b/z.sh
@@ -8,15 +8,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
-
-# In CI containers the checkout directory may be owned by a different uid than
-# the process running this script, triggering git's "dubious ownership" check.
-# Scope the safe.directory override to this single git invocation.
-if [ -n "${CI:-}" ]; then
-	REPO_ROOT="$(git -c safe.directory="$SCRIPT_DIR" -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
-else
-	REPO_ROOT="$(git rev-parse --show-toplevel)"
-fi
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
 
 VENV="$REPO_ROOT/.nanvix/venv"
 

--- a/z.sh
+++ b/z.sh
@@ -7,4 +7,29 @@
 
 set -euo pipefail
 
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+VENV="$REPO_ROOT/.nanvix/venv"
+
+if ! "$VENV/bin/nanvix-zutil" --version &>/dev/null 2>&1 && ! command -v nanvix-zutil &>/dev/null; then
+	echo "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." >&2
+	WHEEL_URL=$(curl -fsSL "https://api.github.com/repos/nanvix/zutils/releases/latest" |
+		python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+wheel = next(
+    a['browser_download_url']
+    for a in data['assets']
+    if a['name'].endswith('.whl')
+)
+print(wheel)
+")
+	python3 -m venv "$VENV"
+	"$VENV/bin/pip" install --quiet "$WHEEL_URL"
+fi
+
+if [ -f "$VENV/bin/activate" ]; then
+	# shellcheck source=/dev/null
+	source "$VENV/bin/activate"
+fi
+
 exec nanvix-zutil "$@"

--- a/z.sh
+++ b/z.sh
@@ -7,6 +7,13 @@
 
 set -euo pipefail
 
+# In CI containers the checkout directory may be owned by a different uid than
+# the process running this script, triggering git's "dubious ownership" check.
+# Mark the current directory safe before calling git rev-parse.
+if [ -n "${CI:-}" ]; then
+	git config --global --add safe.directory "$(pwd)"
+fi
+
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 VENV="$REPO_ROOT/.nanvix/venv"
 


### PR DESCRIPTION
- **feat: add nanvix-zutil bootstrap fallback to z.sh/z.ps1**
- **chore: fix dubious ownership in CI containers**
- **fix: harden bootstrap fallback (review feedback)**
- **fix(bootstrap): remove safe.directory guard, call venv zutil by path in z.ps1**
- **fix(bootstrap): short-circuit when nanvix-zutil is on PATH, normalize scripts**
- **fix: update bootstrappers**
