### PR TITLE
[ci] E: Add 256MB image builds to CI matrix

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -26,6 +26,7 @@ jobs:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.2.0
     with:
       zutil-version: "v0.5.1"
+      memory-sizes: '["128mb","256mb"]'
       caller-event-name: ${{ github.event_name }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Add 256MB memory size to the `nanvix-ci.yml` CI workflow matrix.

### Changes

- Set `memory-sizes: '["128mb","256mb"]'` in the reusable workflow call, overriding the default `["128mb"]`.
- This enables CI to build and test against both 128MB and 256MB Nanvix images across all platform × process-mode combinations.