### PR TITLE
[ci] B: Add pull-requests write to workflow-level permissions

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -16,6 +16,7 @@ permissions:
   contents: write
   actions: write
   issues: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name || github.ref || 'default' }}


### PR DESCRIPTION
Job-level permissions cannot exceed workflow-level. Adding `pull-requests: write` to workflow-level so the `ci-scheduled` job can use it.