### PR TITLE
Enforce LF line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,6 @@
-*	text=auto
+# NANVIX: Windows Docker builds tar-copy sources into a Linux container;
+# eol=lf ensures files arrive with Unix line endings.
+*	text=auto eol=lf
 
 *.sln	text eol=crlf
 *.vcxproj*	text eol=crlf


### PR DESCRIPTION
## Summary

Adds `eol=lf` to the existing `* text=auto` rule in `.gitattributes` so Git always checks out text files with LF endings, regardless of platform. This prevents CRLF line endings from reaching Linux containers via the Docker tar-copy strategy on Windows.

Relates to nanvix/zutils#88.