### PR TITLE
feat(test): add Windows test support

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -13,13 +13,13 @@ Usage:
 
 import shutil
 import tarfile
+import tempfile
 import urllib.request
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import subprocess
 import sys
-from pathlib import Path
 
 from nanvix_zutil import CFG_SYSROOT, CFG_TOOLCHAIN, EXIT_MISSING_DEP, ZScript, log
 
@@ -109,7 +109,7 @@ class LibffiBuild(ZScript):
     def test(self) -> None:
         """Run the test suite.
 
-        On Linux, delegates to the Makefile (smoke + integration + functional).
+        On non-Windows, delegates to the Makefile (smoke + integration + functional).
         On Windows, runs test binaries from build/ via nanvixd.exe natively,
         following the same pattern as posix-tests and cpython.
         """
@@ -129,6 +129,8 @@ class LibffiBuild(ZScript):
         mkramfs = sysroot_path / "bin" / "mkramfs.exe"
         if not nanvixd.is_file():
             log.fatal("nanvixd.exe not found.", code=EXIT_MISSING_DEP, hint="Run `./z setup` first.")
+        if not mkramfs.is_file():
+            log.fatal("mkramfs.exe not found.", code=EXIT_MISSING_DEP, hint="Run `./z setup` first.")
 
         build_dir = self.repo_root / "build"
         test_binaries = sorted(build_dir.glob("*.elf")) if build_dir.is_dir() else []
@@ -138,36 +140,36 @@ class LibffiBuild(ZScript):
             print("OK: library-only repo, no functional tests to run on Windows")
             return
 
-        import shutil
-        import tempfile
         failed = []
         for binary in test_binaries:
             name = binary.stem
             print(f"RUN  {name}...")
-            ramfs_dir = Path(tempfile.mkdtemp(prefix=f"nanvix_{name}_"))
-            (ramfs_dir / "tmp").mkdir(exist_ok=True)
-            shutil.copy2(binary, ramfs_dir / binary.name)
-            ramfs_img = ramfs_dir / "rootfs.img"
-            subprocess.run(
-                [str(mkramfs.resolve()), "-o", str(ramfs_img), str(ramfs_dir)],
-                check=True, capture_output=True,
-            )
-            try:
-                result = subprocess.run(
-                    [str(nanvixd.resolve()), "-bin-dir", str((sysroot_path / "bin").resolve()),
-                     "-ramfs", str(ramfs_img), "--", str(binary.name)],
-                    stdin=subprocess.DEVNULL, timeout=120,
-                )
-                if result.returncode != 0:
-                    print(f"FAIL {name} (exit code {result.returncode})")
+            with tempfile.TemporaryDirectory(prefix=f"nanvix_{name}_") as tmpdir:
+                ramfs_dir = Path(tmpdir)
+                (ramfs_dir / "tmp").mkdir(exist_ok=True)
+                shutil.copy2(binary, ramfs_dir / binary.name)
+                # Write ramfs image outside the source dir to avoid self-inclusion.
+                ramfs_img = ramfs_dir.parent / f"rootfs_{name}.img"
+                try:
+                    subprocess.run(
+                        [str(mkramfs.resolve()), "-o", str(ramfs_img), str(ramfs_dir)],
+                        check=True,
+                    )
+                    result = subprocess.run(
+                        [str(nanvixd.resolve()), "-bin-dir", str((sysroot_path / "bin").resolve()),
+                         "-ramfs", str(ramfs_img), "--", f"./{binary.name}"],
+                        stdin=subprocess.DEVNULL, timeout=120,
+                    )
+                    if result.returncode != 0:
+                        print(f"FAIL {name} (exit code {result.returncode})")
+                        failed.append(name)
+                    else:
+                        print(f"OK   {name}")
+                except subprocess.TimeoutExpired:
+                    print(f"FAIL {name} (timeout)")
                     failed.append(name)
-                else:
-                    print(f"OK   {name}")
-            except subprocess.TimeoutExpired:
-                print(f"FAIL {name} (timeout)")
-                failed.append(name)
-            finally:
-                shutil.rmtree(ramfs_dir, ignore_errors=True)
+                finally:
+                    ramfs_img.unlink(missing_ok=True)
 
         if failed:
             msg = " ".join(failed)

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -145,16 +145,28 @@ class LibffiBuild(ZScript):
             name = binary.stem
             print(f"RUN  {name}...")
             with tempfile.TemporaryDirectory(prefix=f"nanvix_{name}_") as tmpdir:
-                ramfs_dir = Path(tmpdir)
+                tmpdir_path = Path(tmpdir)
+                ramfs_dir = tmpdir_path / "ramfs"
+                ramfs_dir.mkdir()
                 (ramfs_dir / "tmp").mkdir(exist_ok=True)
                 shutil.copy2(binary, ramfs_dir / binary.name)
-                # Write ramfs image outside the source dir to avoid self-inclusion.
-                ramfs_img = ramfs_dir.parent / f"rootfs_{name}.img"
+                # Write ramfs image alongside the ramfs source dir to avoid
+                # self-inclusion while keeping artifacts scoped to this temp dir.
+                ramfs_img = tmpdir_path / f"rootfs_{name}.img"
                 try:
                     subprocess.run(
                         [str(mkramfs.resolve()), "-o", str(ramfs_img), str(ramfs_dir)],
-                        check=True,
+                        check=True, timeout=60,
                     )
+                except subprocess.CalledProcessError as e:
+                    print(f"FAIL {name} (mkramfs exit code {e.returncode})")
+                    failed.append(name)
+                    continue
+                except subprocess.TimeoutExpired:
+                    print(f"FAIL {name} (mkramfs timeout)")
+                    failed.append(name)
+                    continue
+                try:
                     result = subprocess.run(
                         [str(nanvixd.resolve()), "-bin-dir", str((sysroot_path / "bin").resolve()),
                          "-ramfs", str(ramfs_img), "--", f"./{binary.name}"],
@@ -168,8 +180,6 @@ class LibffiBuild(ZScript):
                 except subprocess.TimeoutExpired:
                     print(f"FAIL {name} (timeout)")
                     failed.append(name)
-                finally:
-                    ramfs_img.unlink(missing_ok=True)
 
         if failed:
             msg = " ".join(failed)

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -17,6 +17,10 @@ import urllib.request
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import subprocess
+import sys
+from pathlib import Path
+
 from nanvix_zutil import CFG_SYSROOT, CFG_TOOLCHAIN, EXIT_MISSING_DEP, ZScript, log
 
 # Makefile variable names (build-system-specific).
@@ -33,6 +37,9 @@ _LIBFFI_TARBALL_URL = (
     f"libffi-{_LIBFFI_VERSION}.tar.gz"
 )
 
+
+
+IS_WINDOWS = sys.platform == "win32"
 
 class LibffiBuild(ZScript):
     """Build script for nanvix/libffi."""
@@ -100,14 +107,72 @@ class LibffiBuild(ZScript):
         self.run(*self._make_args("all"), cwd=self.repo_root)
 
     def test(self) -> None:
-        """Run the libffi test suite.
+        """Run the test suite.
 
-        Without targets, runs the full suite (smoke + integration + functional).
-        With targets (e.g. ``./z test -- test-smoke test-integration``), passes
-        them directly to the Makefile.
+        On Linux, delegates to the Makefile (smoke + integration + functional).
+        On Windows, runs test binaries from build/ via nanvixd.exe natively,
+        following the same pattern as posix-tests and cpython.
         """
+        if IS_WINDOWS:
+            self._run_tests_windows()
+            return
         targets = self.targets if self.targets else ["test"]
         self.run(*self._make_args(*targets), cwd=self.repo_root)
+
+    def _run_tests_windows(self) -> None:
+        """Run tests natively on Windows using nanvixd.exe."""
+        sysroot = self.config.get(CFG_SYSROOT, "")
+        if not sysroot:
+            log.fatal(f"{CFG_SYSROOT} is not set.", code=EXIT_MISSING_DEP, hint="Run `./z setup` first.")
+        sysroot_path = Path(sysroot)
+        nanvixd = sysroot_path / "bin" / "nanvixd.exe"
+        mkramfs = sysroot_path / "bin" / "mkramfs.exe"
+        if not nanvixd.is_file():
+            log.fatal("nanvixd.exe not found.", code=EXIT_MISSING_DEP, hint="Run `./z setup` first.")
+
+        build_dir = self.repo_root / "build"
+        test_binaries = sorted(build_dir.glob("*.elf")) if build_dir.is_dir() else []
+
+        if not test_binaries:
+            print("No test binaries found in build/ -- smoke test only.")
+            print("OK: library-only repo, no functional tests to run on Windows")
+            return
+
+        import shutil
+        import tempfile
+        failed = []
+        for binary in test_binaries:
+            name = binary.stem
+            print(f"RUN  {name}...")
+            ramfs_dir = Path(tempfile.mkdtemp(prefix=f"nanvix_{name}_"))
+            (ramfs_dir / "tmp").mkdir(exist_ok=True)
+            shutil.copy2(binary, ramfs_dir / binary.name)
+            ramfs_img = ramfs_dir / "rootfs.img"
+            subprocess.run(
+                [str(mkramfs.resolve()), "-o", str(ramfs_img), str(ramfs_dir)],
+                check=True, capture_output=True,
+            )
+            try:
+                result = subprocess.run(
+                    [str(nanvixd.resolve()), "-bin-dir", str((sysroot_path / "bin").resolve()),
+                     "-ramfs", str(ramfs_img), "--", str(binary.name)],
+                    stdin=subprocess.DEVNULL, timeout=120,
+                )
+                if result.returncode != 0:
+                    print(f"FAIL {name} (exit code {result.returncode})")
+                    failed.append(name)
+                else:
+                    print(f"OK   {name}")
+            except subprocess.TimeoutExpired:
+                print(f"FAIL {name} (timeout)")
+                failed.append(name)
+            finally:
+                shutil.rmtree(ramfs_dir, ignore_errors=True)
+
+        if failed:
+            msg = " ".join(failed)
+            raise RuntimeError(f"{len(failed)} test(s) failed: {msg}")
+        print(f"\t\t*** All {len(test_binaries)} tests PASSED ***")
 
     def release(self) -> None:
         """Package the libffi release tarball and verify it."""


### PR DESCRIPTION
Add Windows-native test execution to `./z test`. On Windows, detects the platform and runs test binaries from `build/` via `nanvixd.exe` with a minimal ramfs — same pattern as posix-tests and cpython. When no test binaries exist (library-only build), passes with a smoke-test-only message.

Also bumps zutil-version to v0.7.25 which adds automatic Windows host binary download in `ZScript.setup()` (nanvix/zutils#123).