### PR TITLE
Bump nanvix-version to 0.12.480

### DIFF
--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libffi"
 version = "3.4.6"
-nanvix-version = "0.12.476"
+nanvix-version = "0.12.480"
 
 [builds]
 [builds.matrix]


### PR DESCRIPTION
Bump `nanvix-version` from `0.12.476` to `0.12.480` to align with cpython's dependency requirements on branch `copilot/add-hyperlight-and-128mb-support`.