### PR TITLE
[ci] Sync zutils v0.7.36

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -27,7 +27,7 @@ jobs:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.13.0
     with:
-      zutil-version: "v0.7.35"
+      zutil-version: "v0.7.36"
       memory-sizes: "[\"128mb\",\"256mb\"]"
       matrix-exclude: "[{\"platform\":\"hyperlight\"}]"
       windows-matrix-exclude: "[{\"platform\":\"hyperlight\"}]"
@@ -47,7 +47,7 @@ jobs:
       pull-requests: write
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.13.0
     with:
-      zutil-version: "v0.7.35"
+      zutil-version: "v0.7.36"
       memory-sizes: "[\"128mb\",\"256mb\"]"
       matrix-exclude: "[{\"platform\":\"hyperlight\"}]"
       windows-matrix-exclude: "[{\"platform\":\"hyperlight\"}]"

--- a/z.ps1
+++ b/z.ps1
@@ -15,7 +15,7 @@ $zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
     $env:NANVIX_ZUTIL_VERSION
 }
 else {
-    "0.7.35"
+    "0.7.36"
 }
 $zutilVersion = $zutilVersion -replace "^v", ""
 
@@ -70,7 +70,7 @@ function Bootstrap {
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         throw "venv creation failed (exit code $LASTEXITCODE)"
     }
-    & $venvPython -m pip install --quiet $wheelUrl
+    & $venvPython -m pip install --quiet "$($wheelUrl)[lint]"
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         throw "pip install failed (exit code $LASTEXITCODE)"
     }

--- a/z.sh
+++ b/z.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-PINNED_VERSION="0.7.35"
+PINNED_VERSION="0.7.36"
 RAW_ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-$PINNED_VERSION}"
 ZUTIL_VERSION="${RAW_ZUTIL_VERSION#v}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
@@ -46,7 +46,7 @@ function bootstrap() {
     fi
     # Re-resolve paths now that the venv exists (Scripts/ vs bin/).
     _resolve_venv_paths
-    "$VENV_PYTHON" -m pip install --quiet "$WHEEL_URL"
+    "$VENV_PYTHON" -m pip install --quiet "${WHEEL_URL}[lint]"
 }
 
 # Prefer the venv copy if it exists; otherwise use the global install.


### PR DESCRIPTION
Automated sync with [`v0.7.36`](https://github.com/nanvix/zutils/releases/tag/v0.7.36):
- Bumps `zutil-version` in caller workflows.
- Copies bootstrapper templates (`z`, `z.sh`, `z.ps1`) from release assets.
- Pins `nanvix-version` to `0.12.502` in `.nanvix/nanvix.toml`.

Generated by the [Update Zutils](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-zutils.yml) workflow.