### PR TITLE
ci: bump nanvix/workflows to v1.14.0

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -7,9 +7,9 @@ on:
   schedule:
     - cron: "0 9 * * *"
   push:
-    branches: [ "nanvix/**" ]
+    branches: ["nanvix/**"]
   pull_request:
-    branches: [ "nanvix/**" ]
+    branches: ["nanvix/**"]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Bumps `nanvix/workflows` from `v1.13.0` to `v1.14.0`, which adds format & lint checks (black, pyright, shfmt, shellcheck, yamllint) to the `nanvix-ci.yml` reusable workflow.

All consumers automatically gain these checks with no other changes needed.