### PR TITLE
ci: enable hyperlight platform in build matrix

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -30,7 +30,9 @@ jobs:
       zutil-version: "v0.7.44"
       platforms: '["hyperlight","microvm"]'
       memory-sizes: "[\"128mb\",\"256mb\"]"
-      matrix-exclude: '[{"platform":"hyperlight","process-mode":"multi-process"},{"platform":"hyperlight","process-mode":"single-process"}]'
+      matrix-exclude: >-
+        [{"platform":"hyperlight","process-mode":"multi-process"},
+        {"platform":"hyperlight","process-mode":"single-process"}]
       windows-matrix-exclude: '[]'
       skip-full-test-modes: "[]"
       caller-event-name: ${{ github.event_name }}
@@ -51,7 +53,9 @@ jobs:
       zutil-version: "v0.7.44"
       platforms: '["hyperlight","microvm"]'
       memory-sizes: "[\"128mb\",\"256mb\"]"
-      matrix-exclude: '[{"platform":"hyperlight","process-mode":"multi-process"},{"platform":"hyperlight","process-mode":"single-process"}]'
+      matrix-exclude: >-
+        [{"platform":"hyperlight","process-mode":"multi-process"},
+        {"platform":"hyperlight","process-mode":"single-process"}]
       windows-matrix-exclude: '[]'
       skip-full-test-modes: "[]"
       caller-event-name: "schedule"

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -28,9 +28,10 @@ jobs:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.14.0
     with:
       zutil-version: "v0.7.44"
+      platforms: '["hyperlight","microvm"]'
       memory-sizes: "[\"128mb\",\"256mb\"]"
-      matrix-exclude: "[{\"platform\":\"hyperlight\"}]"
-      windows-matrix-exclude: "[{\"platform\":\"hyperlight\"}]"
+      matrix-exclude: '[{"platform":"hyperlight","process-mode":"multi-process"},{"platform":"hyperlight","process-mode":"single-process"}]'
+      windows-matrix-exclude: '[]'
       skip-full-test-modes: "[]"
       caller-event-name: ${{ github.event_name }}
       windows-test: true
@@ -48,9 +49,10 @@ jobs:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.14.0
     with:
       zutil-version: "v0.7.44"
+      platforms: '["hyperlight","microvm"]'
       memory-sizes: "[\"128mb\",\"256mb\"]"
-      matrix-exclude: "[{\"platform\":\"hyperlight\"}]"
-      windows-matrix-exclude: "[{\"platform\":\"hyperlight\"}]"
+      matrix-exclude: '[{"platform":"hyperlight","process-mode":"multi-process"},{"platform":"hyperlight","process-mode":"single-process"}]'
+      windows-matrix-exclude: '[]'
       skip-full-test-modes: "[]"
       caller-event-name: "schedule"
       windows-test: true


### PR DESCRIPTION
## Summary

- Remove `matrix-exclude` and `windows-matrix-exclude` entries that were disabling the hyperlight platform in CI
- Hyperlight was already declared in the build matrix (`platforms: ["hyperlight","microvm"]`) but excluded at the workflow level — this unblocks it

Depends on the Hyperlight HAL frame allocator fix in nanvix/nanvix which resolves the `frame allocator storage too small for sparse layout` kernel panic in standalone mode.

## Issues

- Closes #152 
- Closes #153 