### PR TITLE
[ci] Sync zutils v0.7.47

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -27,7 +27,7 @@ jobs:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.14.0
     with:
-      zutil-version: "v0.7.45"
+      zutil-version: "v0.7.47"
       platforms: '["hyperlight","microvm"]'
       memory-sizes: "[\"128mb\",\"256mb\"]"
       matrix-exclude: >-
@@ -50,7 +50,7 @@ jobs:
       pull-requests: write
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.14.0
     with:
-      zutil-version: "v0.7.45"
+      zutil-version: "v0.7.47"
       platforms: '["hyperlight","microvm"]'
       memory-sizes: "[\"128mb\",\"256mb\"]"
       matrix-exclude: >-

--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libffi"
 version = "3.4.6"
-nanvix-version = "0.12.534"
+nanvix-version = "0.12.536"
 
 [builds]
 [builds.matrix]

--- a/z.ps1
+++ b/z.ps1
@@ -15,7 +15,7 @@ $zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
     $env:NANVIX_ZUTIL_VERSION
 }
 else {
-    "0.7.45"
+    "0.7.47"
 }
 $zutilVersion = $zutilVersion -replace "^v", ""
 

--- a/z.sh
+++ b/z.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-PINNED_VERSION="0.7.45"
+PINNED_VERSION="0.7.47"
 RAW_ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-$PINNED_VERSION}"
 ZUTIL_VERSION="${RAW_ZUTIL_VERSION#v}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"


### PR DESCRIPTION
Automated sync with [`v0.7.47`](https://github.com/nanvix/zutils/releases/tag/v0.7.47):
- Bumps `zutil-version` in caller workflows.
- Copies bootstrapper templates (`z`, `z.sh`, `z.ps1`) from release assets.
- Pins `nanvix-version` to `0.12.536` in `.nanvix/nanvix.toml`.

Generated by the [Update Zutils](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-zutils.yml) workflow.