### PR TITLE
build: migrate Docker image to ghcr.io/nanvix/toolchain-gcc

### DIFF
--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -24,7 +24,7 @@
 # Toolchain Detection
 # ===========================================================================
 
-NANVIX_DOCKER_IMAGE ?= nanvix/toolchain:latest-minimal
+NANVIX_DOCKER_IMAGE ?= ghcr.io/nanvix/toolchain-gcc:sha-34a3641
 
 ifdef CONFIG_NANVIX
   NANVIX_TOOLCHAIN ?= /opt/nanvix

--- a/NANVIX.md
+++ b/NANVIX.md
@@ -61,7 +61,7 @@ Or build directly with Make (advanced):
 
 ```bash
 # 1. Pull the Docker image
-docker pull nanvix/toolchain:latest-minimal
+docker pull ghcr.io/nanvix/toolchain-gcc:sha-34a3641
 
 # 2. Download Nanvix sysroot
 curl -fsSL https://raw.githubusercontent.com/nanvix/nanvix/refs/heads/dev/scripts/get-nanvix.sh | bash -s -- nanvix-artifacts
@@ -132,7 +132,7 @@ The Makefile supports automatic Docker fallback when the native toolchain is not
 
 ```bash
 # Pull the Nanvix toolchain Docker image
-docker pull nanvix/toolchain:latest-minimal
+docker pull ghcr.io/nanvix/toolchain-gcc:sha-34a3641
 
 # Build (Docker is used automatically if native toolchain is not found)
 make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/nanvix/sysroot-debug
@@ -144,7 +144,7 @@ make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/nanvix/sysroot-debu
 - If `NANVIX_TOOLCHAIN` points to a valid toolchain, it uses the native compiler
 - If the native toolchain is not found, it automatically uses Docker if available
 - Use `CONFIG_NANVIX_DOCKER=y` to force Docker usage even when native toolchain exists
-- Use `NANVIX_DOCKER_IMAGE` to specify a custom Docker image (default: `nanvix/toolchain:latest-minimal`)
+- Use `NANVIX_DOCKER_IMAGE` to specify a custom Docker image (default: `ghcr.io/nanvix/toolchain-gcc:sha-34a3641`)
 
 ### Using Native Toolchain
 


### PR DESCRIPTION
## Summary

Migrates the cross-compilation Docker image from `nanvix/toolchain:latest-minimal` (Docker Hub) to `ghcr.io/nanvix/toolchain-gcc:sha-34a3641` (GitHub Container Registry).

Closes #162

## Changes

- **`Makefile.nanvix`** — Updated `NANVIX_DOCKER_IMAGE` default
- **`NANVIX.md`** — Updated `docker pull` instructions and default image reference

## Validation

Built libffi and ran all test levels locally using the new GHCR image:
- ✅ Smoke tests (libffi.a exists, ffi.h present)
- ✅ Integration tests (archive contains 14 objects)
- ✅ Functional tests (ffi_test.elf ran successfully inside nanvixd.elf)