### PR TITLE
[ci] E: Update nanvix workflow refs to v1.15.0

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   ci:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.14.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.15.0
     with:
       zutil-version: "v0.7.48"
       platforms: '["microvm"]'
@@ -45,7 +45,7 @@ jobs:
       actions: write
       issues: write
       pull-requests: write
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.14.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.15.0
     with:
       zutil-version: "v0.7.48"
       platforms: '["microvm"]'

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -310,10 +310,10 @@ package: build
 	  find . -name "ffitarget.h" -path "*/x86/*" -not -path "*/nanvix-artifacts/*" -not -path "*/dist/*" -exec cp -f {} dist/$(ARTIFACT_NAME)/sysroot/include/ \; ; \
 	fi
 	-cp -f ffi_test$(EXE) dist/$(ARTIFACT_NAME)/sysroot/bin/ 2>/dev/null || true
-	tar -cjf dist/$(ARTIFACT_NAME).tar.bz2 -C dist/$(ARTIFACT_NAME) sysroot
-	@echo "  Package: dist/$(ARTIFACT_NAME).tar.bz2"
+	tar -czf dist/$(ARTIFACT_NAME).tar.gz -C dist/$(ARTIFACT_NAME) sysroot
+	@echo "  Package: dist/$(ARTIFACT_NAME).tar.gz"
 	@echo "  Contents:"
-	@tar tjf dist/$(ARTIFACT_NAME).tar.bz2 | head -20
+	@tar tzf dist/$(ARTIFACT_NAME).tar.gz | head -20
 
 # ===========================================================================
 # Verify Package
@@ -322,13 +322,13 @@ package: build
 verify-package:
 	@echo "=== Verifying libffi package ==="
 	$(eval ARTIFACT_NAME := libffi-$(PLATFORM)-$(PROCESS_MODE)-$(MEMORY_SIZE))
-	@TARBALL="dist/$(ARTIFACT_NAME).tar.bz2"; \
+	@TARBALL="dist/$(ARTIFACT_NAME).tar.gz"; \
 	if [ ! -f "$$TARBALL" ]; then \
 	  echo "FAIL: Package tarball not found: $$TARBALL"; exit 1; \
 	fi; \
 	echo "Package contents:"; \
-	tar tjf "$$TARBALL"; \
-	if ! tar tjf "$$TARBALL" | grep -q 'sysroot/lib/'; then \
+	tar tzf "$$TARBALL"; \
+	if ! tar tzf "$$TARBALL" | grep -q 'sysroot/lib/'; then \
 	  echo "FAIL: Package missing sysroot/lib/ entries"; exit 1; \
 	fi; \
 	echo "  PASS: libffi package verification"


### PR DESCRIPTION
Automated bump of `nanvix/workflows` references to [`v1.15.0`](https://github.com/nanvix/workflows/releases/tag/v1.15.0).

Generated by the [Update Workflow Refs](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-workflows.yml) workflow.