### PR TITLE
ci: bump workflows to v2.0.0 and zutils to v0.8.1

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -25,15 +25,16 @@ concurrency:
 jobs:
   ci:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.15.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.0
     with:
-      zutil-version: "v0.7.48"
+      zutil-version: "v0.8.1"
       platforms: '["microvm"]'
       memory-sizes: "[\"128mb\",\"256mb\"]"
       windows-matrix-exclude: '[]'
       skip-full-test-modes: "[]"
       caller-event-name: ${{ github.event_name }}
       windows-test: true
+      docker-image: "ghcr.io/nanvix/toolchain-gcc:sha-34a3641" # yamllint disable-line rule:line-length
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
@@ -45,15 +46,16 @@ jobs:
       actions: write
       issues: write
       pull-requests: write
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.15.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.0
     with:
-      zutil-version: "v0.7.48"
+      zutil-version: "v0.8.1"
       platforms: '["microvm"]'
       memory-sizes: "[\"128mb\",\"256mb\"]"
       windows-matrix-exclude: '[]'
       skip-full-test-modes: "[]"
       caller-event-name: "schedule"
       windows-test: true
+      docker-image: "ghcr.io/nanvix/toolchain-gcc:sha-34a3641" # yamllint disable-line rule:line-length
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}

--- a/z.ps1
+++ b/z.ps1
@@ -15,7 +15,7 @@ $zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
     $env:NANVIX_ZUTIL_VERSION
 }
 else {
-    "0.7.48"
+    "0.8.1"
 }
 $zutilVersion = $zutilVersion -replace "^v", ""
 

--- a/z.sh
+++ b/z.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-PINNED_VERSION="0.7.48"
+PINNED_VERSION="0.8.1"
 RAW_ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-$PINNED_VERSION}"
 ZUTIL_VERSION="${RAW_ZUTIL_VERSION#v}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"


### PR DESCRIPTION
## Summary

Adapt caller workflow to breaking changes introduced by:

- `nanvix/workflows` v2.0.0 — `docker-image` is now a required input (no default).
- `nanvix/zutils` v0.8.0 — `setup --with-docker` requires an explicit image argument.

### Changes

- Bump `nanvix/workflows` from `v1.15.0` → `v2.0.0`
- Bump `zutil-version` from `v0.7.48` → `v0.8.1`
- Add `docker-image: ghcr.io/nanvix/toolchain-gcc:sha-34a3641` to both `ci` and `ci-scheduled` jobs

Supersedes: #176, #177