### PR TITLE
[ci] Sync zutils v0.8.2

### DIFF
--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libffi"
 version = "3.4.6"
-nanvix-version = "0.13.3"
+nanvix-version = "0.13.11"
 
 [builds]
 [builds.matrix]


### PR DESCRIPTION
Automated sync with [`v0.8.2`](https://github.com/nanvix/zutils/releases/tag/v0.8.2):
- Bumps `zutil-version` in caller workflows.
- Copies bootstrapper templates (`z`, `z.sh`, `z.ps1`) from release assets.
- Pins `nanvix-version` to `0.13.11` in `.nanvix/nanvix.toml`.

Generated by the [Update Zutils](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-zutils.yml) workflow.