### PR TITLE
Use make_initrd for functional tests and update nanvix version

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -28,7 +28,7 @@ jobs:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.1
     with:
-      zutil-version: "v0.8.5"
+      zutil-version: "v0.9.0"
       platforms: '["microvm"]'
       memory-sizes: "[\"128mb\",\"256mb\"]"
       windows-matrix-exclude: '[]'
@@ -44,7 +44,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.1
     with:
-      zutil-version: "v0.8.5"
+      zutil-version: "v0.9.0"
       platforms: '["microvm"]'
       memory-sizes: "[\"128mb\",\"256mb\"]"
       windows-matrix-exclude: '[]'

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -13,7 +13,6 @@ Usage:
 """
 
 import shutil
-import subprocess
 import sys
 import tarfile
 import tempfile
@@ -124,23 +123,93 @@ class LibffiBuild(ZScript):
     def test(self) -> None:
         """Run the test suite.
 
-        On non-Windows, delegates to the Makefile (smoke + integration + functional).
-        On Windows, runs test binaries from build/ via nanvixd.exe natively,
-        following the same pattern as posix-tests and cpython.
+        Smoke and integration tests are always delegated to the Makefile.
+        The functional test in standalone mode is handled in Python via
+        make_initrd so that initrd creation is shared across platforms.
         """
         if IS_WINDOWS:
             self._run_tests_windows()
             return
-        targets = self.targets if self.targets else ["test"]
-        self.run(*self._make_args(*targets), cwd=self.repo_root)
+
+        if self.config.deployment_mode == "standalone":
+            # Smoke + integration via Makefile, functional via Python.
+            self.run(
+                *self._make_args("test-smoke", "test-integration"), cwd=self.repo_root
+            )
+            self._run_functional_standalone()
+        else:
+            targets = self.targets if self.targets else ["test"]
+            self.run(*self._make_args(*targets), cwd=self.repo_root)
+
+    def _run_functional_standalone(self) -> None:
+        """Run the standalone functional test using make_initrd.
+
+        Creates an initrd bundling ffi_test.elf with system daemons via
+        make_initrd, and a ramfs providing /tmp for test file output.
+        """
+        # Build the test binary (cross-compile via Docker/native toolchain).
+        self.run(*self._make_args("test-functional-build"), cwd=self.repo_root)
+
+        ffi_test_elf = self.repo_root / "ffi_test.elf"
+        if not ffi_test_elf.is_file():
+            log.fatal(
+                "ffi_test.elf not found after build.",
+                code=EXIT_MISSING_DEP,
+                hint="Check test-functional-build output for errors.",
+            )
+
+        print("=== libffi functional tests ===")
+        print("  Running ffi_test.elf via nanvixd standalone...")
+
+        sysroot = self.config.get(CFG_SYSROOT, "")
+        sysroot_path = Path(sysroot)
+        mkramfs = sysroot_path / "bin" / "mkramfs.elf"
+
+        # Bundle ffi_test.elf + daemons into an initrd.
+        initrd = self.make_initrd("ffi_test.elf")
+
+        try:
+            with tempfile.TemporaryDirectory(prefix="nanvix_ffi_") as tmpdir:
+                tmpdir_path = Path(tmpdir)
+                ramfs_dir = tmpdir_path / "ramfs"
+                ramfs_dir.mkdir()
+                (ramfs_dir / "tmp").mkdir(exist_ok=True)
+                ramfs_img = tmpdir_path / "rootfs.img"
+
+                self.run(
+                    str(mkramfs),
+                    "-o",
+                    str(ramfs_img),
+                    str(ramfs_dir),
+                    docker=False,
+                )
+
+                self.run(
+                    str(sysroot_path / "bin" / "nanvixd.elf"),
+                    "-bin-dir",
+                    str(sysroot_path / "bin"),
+                    "-ramfs",
+                    str(ramfs_img),
+                    "--",
+                    str(initrd),
+                    docker=False,
+                    timeout=120,
+                )
+        finally:
+            if initrd.exists():
+                initrd.unlink()
+
+        print("  PASS: ffi_test standalone (exit code 0)")
+        print("  PASS: libffi functional tests")
+        print("=== All libffi tests PASSED ===")
 
     def _run_tests_windows(self) -> None:
         """Run tests natively on Windows using nanvixd.exe.
 
         Only standalone mode is tested on Windows; multi-process and
-        single-process require linuxd, which is Linux-only.  Standalone
-        test binaries are discovered in the repository root, where the
-        Makefile emits the ELF outputs, then fall back to ``build/``.
+        single-process require linuxd, which is Linux-only.  Uses
+        make_initrd to bundle each test binary with system daemons,
+        and a ramfs providing /tmp for any test I/O.
         """
         if self.config.deployment_mode != "standalone":
             print(
@@ -196,56 +265,59 @@ class LibffiBuild(ZScript):
                 ),
             )
 
-        failed = []
+        failed: list[str] = []
         for binary in test_binaries:
             name = binary.stem
             print(f"RUN  {name}...")
-            with tempfile.TemporaryDirectory(prefix=f"nanvix_{name}_") as tmpdir:
-                tmpdir_path = Path(tmpdir)
-                ramfs_dir = tmpdir_path / "ramfs"
-                ramfs_dir.mkdir()
-                (ramfs_dir / "tmp").mkdir(exist_ok=True)
-                shutil.copy2(binary, ramfs_dir / binary.name)
-                # Write ramfs image alongside the ramfs source dir to avoid
-                # self-inclusion while keeping artifacts scoped to this temp dir.
-                ramfs_img = tmpdir_path / f"rootfs_{name}.img"
-                try:
-                    subprocess.run(
-                        [str(mkramfs.resolve()), "-o", str(ramfs_img), str(ramfs_dir)],
-                        check=True,
-                        timeout=60,
+            # make_initrd resolves binaries relative to repo_root;
+            # copy the ELF there temporarily unless it already lives there.
+            repo_elf = self.repo_root / binary.name
+            copied_elf = False
+            initrd: Path | None = None
+            try:
+                if binary.resolve() != repo_elf.resolve():
+                    if repo_elf.exists():
+                        raise FileExistsError(
+                            f"refusing to clobber existing {repo_elf}"
+                        )
+                    shutil.copy2(binary, repo_elf)
+                    copied_elf = True
+                initrd = self.make_initrd(binary.name)
+                with tempfile.TemporaryDirectory(prefix=f"nanvix_{name}_") as tmpdir:
+                    tmpdir_path = Path(tmpdir)
+                    ramfs_dir = tmpdir_path / "ramfs"
+                    ramfs_dir.mkdir()
+                    (ramfs_dir / "tmp").mkdir(exist_ok=True)
+                    ramfs_img = tmpdir_path / f"rootfs_{name}.img"
+
+                    self.run(
+                        str(mkramfs),
+                        "-o",
+                        str(ramfs_img),
+                        str(ramfs_dir),
+                        docker=False,
                     )
-                except subprocess.CalledProcessError as e:
-                    print(f"FAIL {name} (mkramfs exit code {e.returncode})")
-                    failed.append(name)
-                    continue
-                except subprocess.TimeoutExpired:
-                    print(f"FAIL {name} (mkramfs timeout)")
-                    failed.append(name)
-                    continue
-                try:
-                    result = subprocess.run(
-                        [
-                            str(nanvixd.resolve()),
-                            "-bin-dir",
-                            str((sysroot_path / "bin").resolve()),
-                            "-ramfs",
-                            str(ramfs_img),
-                            "--",
-                            f"./{binary.name}",
-                        ],
-                        stdin=subprocess.DEVNULL,
+
+                    self.run(
+                        str(nanvixd),
+                        "-bin-dir",
+                        str(sysroot_path / "bin"),
+                        "-ramfs",
+                        str(ramfs_img),
+                        "--",
+                        str(initrd),
+                        docker=False,
                         timeout=120,
-                        check=False,
                     )
-                    if result.returncode != 0:
-                        print(f"FAIL {name} (exit code {result.returncode})")
-                        failed.append(name)
-                    else:
-                        print(f"OK   {name}")
-                except subprocess.TimeoutExpired:
-                    print(f"FAIL {name} (timeout)")
-                    failed.append(name)
+                print(f"OK   {name}")
+            except SystemExit:
+                print(f"FAIL {name}")
+                failed.append(name)
+            finally:
+                if initrd is not None and initrd.exists():
+                    initrd.unlink()
+                if copied_elf and repo_elf.exists():
+                    repo_elf.unlink()
 
         if failed:
             msg = " ".join(failed)

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -187,10 +187,9 @@ else
 endif
 	@echo "  PASS: libffi integration tests"
 
-# --- Functional tests: build and run a minimal FFI test ---
-test-functional:
-	@echo "=== libffi functional tests ==="
-ifeq ($(PROCESS_MODE),standalone)
+# --- Build the functional test binary (compile only, no run) ---
+test-functional-build:
+	@echo "=== Building ffi_test$(EXE) ==="
 ifdef CONFIG_NANVIX_DOCKER
 	@LIBFFI=$$(find . -name "libffi.a" -not -path "*/nanvix-artifacts/*" -not -path "*/dist/*" | head -1); \
 	  FFI_INCLUDE=$$(find . -path "*/include/ffi.h" -not -path "*/nanvix-artifacts/*" -not -path "*/dist/*" -exec dirname {} \; | head -1); \
@@ -205,15 +204,6 @@ ifdef CONFIG_NANVIX_DOCKER
 	    -o ffi_test$(EXE); \
 	  rm -f _ffi_test.c; \
 	  echo "  OK: ffi_test$(EXE) built ($$(wc -c < ffi_test$(EXE)) bytes)"
-	@echo "  Running ffi_test$(EXE) via nanvixd.elf standalone (Docker)..."
-	$(DOCKER_RUN_FUNCTIONAL) sh -c '\
-	  mkdir -p /tmp/nanvix-ramfs && \
-	  cp $(DOCKER_WORKSPACE_PATH)/ffi_test$(EXE) /tmp/nanvix-ramfs/ && \
-	  ./bin/mkramfs.elf -o /tmp/rootfs.img /tmp/nanvix-ramfs/ && \
-	  timeout --foreground 120 ./bin/nanvixd.elf \
-	    -bin-dir ./bin -ramfs /tmp/rootfs.img \
-	    -- $(DOCKER_WORKSPACE_PATH)/ffi_test$(EXE)'
-	@echo "  PASS: ffi_test standalone (exit code 0)"
 else
 	@LIBFFI=$$(find . -name "libffi.a" -not -path "*/nanvix-artifacts/*" -not -path "*/dist/*" | head -1); \
 	  FFI_INCLUDE=$$(find . -path "*/include/ffi.h" -not -path "*/nanvix-artifacts/*" -not -path "*/dist/*" -exec dirname {} \; | head -1); \
@@ -228,16 +218,15 @@ else
 	    -o ffi_test$(EXE); \
 	  rm -f /tmp/ffi_test.c; \
 	  echo "  OK: ffi_test$(EXE) built ($$(wc -c < ffi_test$(EXE)) bytes)"
-	@echo "  Running ffi_test$(EXE) via nanvixd.elf standalone..."
-	@rm -rf /tmp/nanvix-ramfs && mkdir -p /tmp/nanvix-ramfs
-	@cp $(abspath ffi_test$(EXE)) /tmp/nanvix-ramfs/
-	"$(SYSROOT_PATH)/bin/mkramfs.elf" -o /tmp/rootfs.img /tmp/nanvix-ramfs/
-	cd "$(SYSROOT_PATH)" && timeout --foreground 120 ./bin/nanvixd.elf \
-	  -bin-dir ./bin -ramfs /tmp/rootfs.img \
-	  -- $(abspath ffi_test$(EXE))
-	@rm -rf /tmp/nanvix-ramfs /tmp/rootfs.img
-	@echo "  PASS: ffi_test standalone (exit code 0)"
 endif
+
+# --- Functional tests: build and run a minimal FFI test ---
+test-functional:
+	@echo "=== libffi functional tests ==="
+ifeq ($(PROCESS_MODE),standalone)
+	@echo "  NOTE: Standalone functional tests are handled via ./z.sh."
+	@echo "  Delegating to: ./z.sh test test-functional"
+	@./z.sh --with-nanvix "$(NANVIX_HOME)" test test-functional
 else
 ifdef CONFIG_NANVIX_DOCKER
 	@LIBFFI=$$(find . -name "libffi.a" -not -path "*/nanvix-artifacts/*" -not -path "*/dist/*" | head -1); \

--- a/z.ps1
+++ b/z.ps1
@@ -15,7 +15,7 @@ $zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
     $env:NANVIX_ZUTIL_VERSION
 }
 else {
-    "0.8.5"
+    "0.9.0"
 }
 $zutilVersion = $zutilVersion -replace "^v", ""
 
@@ -42,9 +42,10 @@ catch {
 }
 
 function Bootstrap {
+    param([string]$Reason = "not found")
     # Pin nanvix-zutil version for reproducible bootstrapping.
     # Override with NANVIX_ZUTIL_VERSION env var if needed.
-    Write-Information "nanvix-zutil not found -- bootstrapping nanvix-zutil==${zutilVersion}..." -InformationAction Continue
+    Write-Information "nanvix-zutil ${Reason} -- bootstrapping nanvix-zutil==${zutilVersion}..." -InformationAction Continue
 
     $wheelUrl = "https://github.com/nanvix/zutils/releases/download/v${zutilVersion}/nanvix_zutil-${zutilVersion}-py3-none-any.whl"
 
@@ -115,6 +116,11 @@ else {
     $bin = "nanvix-zutil"
     if ($zutilGlobalVersion -ne "nanvix-zutil ${zutilVersion}") {
         Write-Warning "nanvix-zutil global install does not match expected version. Expected ${zutilVersion}, found ${zutilGlobalVersion}."
+        Bootstrap "version mismatch"
+        if (-not (Test-Path $venvZutil)) {
+            throw "Bootstrap completed but $venvZutil not found."
+        }
+        $bin = $venvZutil
     }
 }
 

--- a/z.sh
+++ b/z.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-PINNED_VERSION="0.8.5"
+PINNED_VERSION="0.9.0"
 RAW_ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-$PINNED_VERSION}"
 ZUTIL_VERSION="${RAW_ZUTIL_VERSION#v}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
@@ -31,7 +31,8 @@ ZUTIL_GLOBAL_VERSION="$(nanvix-zutil --version 2>/dev/null || true)"
 function bootstrap() {
     # Pin nanvix-zutil version for reproducible bootstrapping.
     # Override with NANVIX_ZUTIL_VERSION env var if needed.
-    echo "nanvix-zutil not found -- bootstrapping nanvix-zutil==${ZUTIL_VERSION}..." >&2
+    local reason="${1:-not found}"
+    echo "nanvix-zutil ${reason} -- bootstrapping nanvix-zutil==${ZUTIL_VERSION}..." >&2
 
     if ! command -v python3 &>/dev/null; then
         echo "Error: python3 not found. Install Python 3 and ensure python3 is on PATH." >&2
@@ -69,6 +70,8 @@ else
     BIN="nanvix-zutil"
     if [ "$ZUTIL_GLOBAL_VERSION" != "nanvix-zutil ${ZUTIL_VERSION}" ]; then
         echo "Warning: nanvix-zutil global install does not match expected version. Expected ${ZUTIL_VERSION}, found ${ZUTIL_GLOBAL_VERSION}." >&2
+        bootstrap "version mismatch"
+        BIN="$VENV_BIN"
     fi
 fi
 


### PR DESCRIPTION
Adapt to breaking changes in Nanvix v0.13.19 by using `make_initrd` to bundle test programs in a multi-binary initrd with system daemons, instead of placing binaries directly in the ramfs. Follows the same pattern established in nanvix/zlib#203, nanvix/bzip2#230, and nanvix/xz#47.

## Changes

- **z.py**: Refactor `test()` to separate standalone mode from multi-process/single-process. Standalone functional tests are now handled in Python via `_run_functional_standalone()` which uses `self.make_initrd('ffi_test.elf')` to create an initrd bundling the test binary with system daemons, and a separate ramfs for `/tmp` I/O.
- **z.py**: Refactor `_run_tests_windows()` to use `make_initrd` and `self.run(..., docker=False)` instead of raw `subprocess.run()` calls, with consistent error handling via `SystemExit` and cleanup in `finally` blocks.
- **z.py**: Remove unused `subprocess` import.
- **Makefile.nanvix**: Delegate standalone `test-functional` to `./z.sh` so direct Makefile users get functional coverage rather than duplicating the initrd logic in shell.
- **Makefile.nanvix**: Non-standalone paths (multi-process, single-process) remain unchanged — they run nanvixd directly without initrd as daemons are managed by the hypervisor.
- **z.sh / z.ps1**: Update nanvix-zutil pinned version to 0.9.0 and bootstrap on version mismatch.
- **nanvix-ci.yml**: Update CI workflow to use zutil v0.9.0.

No test programs are disabled in any deployment mode (standalone, multi-process, single-process).