### PR TITLE
Regenerate autotools in Docker via toolchain-libffi image

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -35,7 +35,7 @@ jobs:
       skip-full-test-modes: "[]"
       caller-event-name: ${{ github.event_name }}
       windows-test: true
-      docker-image: "ghcr.io/nanvix/toolchain-gcc:sha-34a3641" # yamllint disable-line rule:line-length
+      docker-image: "ghcr.io/nanvix/toolchain-libffi:latest" # yamllint disable-line rule:line-length
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
       skip-full-test-modes: "[]"
       caller-event-name: "schedule"
       windows-test: true
-      docker-image: "ghcr.io/nanvix/toolchain-gcc:sha-34a3641" # yamllint disable-line rule:line-length
+      docker-image: "ghcr.io/nanvix/toolchain-libffi:latest" # yamllint disable-line rule:line-length
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}

--- a/.github/workflows/nanvix-docker-image.yml
+++ b/.github/workflows/nanvix-docker-image.yml
@@ -1,0 +1,59 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+name: Docker Image
+
+on:
+  push:
+    branches: ["nanvix/**"]
+    paths:
+      - ".nanvix/docker/Dockerfile"
+      - ".github/workflows/nanvix-docker-image.yml"
+  pull_request:
+    branches: ["nanvix/**"]
+    paths:
+      - ".nanvix/docker/Dockerfile"
+      - ".github/workflows/nanvix-docker-image.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: nanvix/toolchain-libffi
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .nanvix/docker
+          file: .nanvix/docker/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.nanvix/.gitignore
+++ b/.nanvix/.gitignore
@@ -6,5 +6,4 @@ buildroot/
 .yamllint.yml
 black.toml
 env.json
-nanvix.lock
 pyrightconfig.json

--- a/.nanvix/docker/Dockerfile
+++ b/.nanvix/docker/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# toolchain-libffi — Nanvix GCC toolchain + autotools for libffi
+# cross-compilation. Published as ghcr.io/nanvix/toolchain-libffi.
+#
+# The base image ships the i686-nanvix cross-compiler but does not include
+# autoconf / automake / libtool. libffi's Makefile.nanvix runs `autoreconf -i`
+# from the configure target, so those tools must be available inside the
+# container.
+
+FROM ghcr.io/nanvix/toolchain-gcc:sha-34a3641
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        autoconf \
+        automake \
+        libtool \
+        libltdl-dev \
+        m4 \
+        texinfo \
+    && rm -rf /var/lib/apt/lists/*

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -14,11 +14,8 @@ Usage:
 
 import shutil
 import sys
-import tarfile
 import tempfile
-import urllib.request
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
 from nanvix_zutil import (  # type: ignore[import-not-found]
     CFG_SYSROOT,
@@ -34,12 +31,6 @@ _MAKE_VAR_TOOLCHAIN = "NANVIX_TOOLCHAIN"
 _MAKE_VAR_PLATFORM = "PLATFORM"
 _MAKE_VAR_PROCESS_MODE = "PROCESS_MODE"
 _MAKE_VAR_MEMORY_SIZE = "MEMORY_SIZE"
-
-_LIBFFI_VERSION = "3.4.6"
-_LIBFFI_TARBALL_URL = (
-    f"https://github.com/libffi/libffi/releases/download/v{_LIBFFI_VERSION}/"
-    f"libffi-{_LIBFFI_VERSION}.tar.gz"
-)
 
 
 IS_WINDOWS = sys.platform == "win32"
@@ -79,39 +70,15 @@ class LibffiBuild(ZScript):
         args.extend(targets)
         return args
 
-    def _ensure_configure(self) -> None:
-        """Download the release tarball if ``./configure`` is missing.
-
-        Git checkouts of libffi do not include the autotools-generated
-        ``configure`` script.  When it is absent we fetch the official
-        release tarball and overlay it onto the working tree.
-        """
-        configure = self.repo_root / "configure"
-        if configure.exists():
-            return
-
-        log.info("configure script not found — downloading release tarball")
-        with TemporaryDirectory() as tmp:
-            tarball = Path(tmp) / f"libffi-{_LIBFFI_VERSION}.tar.gz"
-            urllib.request.urlretrieve(_LIBFFI_TARBALL_URL, tarball)
-            with tarfile.open(tarball, "r:gz") as tf:
-                if sys.version_info >= (3, 12):
-                    tf.extractall(tmp, filter="data")
-                else:
-                    tf.extractall(tmp)  # noqa: S202
-            extracted = Path(tmp) / f"libffi-{_LIBFFI_VERSION}"
-            for item in extracted.iterdir():
-                dest = self.repo_root / item.name
-                if item.is_dir():
-                    shutil.copytree(item, dest, dirs_exist_ok=True)
-                else:
-                    shutil.copy2(item, dest)
-        log.info("configure script ready")
-
     def setup(self) -> None:
-        """Download the Nanvix sysroot and prepare autotools sources."""
+        """Download the Nanvix sysroot.
+
+        The autotools build system (``configure``, ``Makefile.in``, ...)
+        is regenerated on demand by ``Makefile.nanvix`` inside the Docker
+        toolchain image (see the ``configure`` target there).  No
+        host-side autotools install is required.
+        """
         super().setup()
-        self._ensure_configure()
 
     def build(self) -> None:
         """Cross-compile libffi.a and ffi_test.elf for Nanvix.

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -81,9 +81,18 @@ NANVIX_LIBS := -Wl,--start-group \
 
 all: build ffi_test$(EXE)
 
-$(CONFIGURED_MARKER):
-	@# Patch config.sub to recognize nanvix (idempotent; defensive against
-	@# tarball overlay performed by .nanvix/z.py's _ensure_configure()).
+# Regenerate the autotools build system from configure.ac / Makefile.am.
+# Runs inside the Docker toolchain image (which provides autoconf,
+# automake, and libtool), so no autotools install is required on the
+# host.  Re-runs only when the autotools inputs change.
+configure: configure.ac Makefile.am acinclude.m4 $(wildcard m4/*.m4)
+	autoreconf -v -i -f
+	@touch configure
+
+$(CONFIGURED_MARKER): configure
+	@# Patch config.sub to recognize nanvix (idempotent; defends against
+	@# autoreconf -i replacing it with an upstream copy from automake's
+	@# data dir).
 	@if [ -f config.sub ] && ! grep -q 'nanvix' config.sub; then \
 	  sed -i 's/| fiwix\* )/| fiwix* | nanvix* )/' config.sub; \
 	fi

--- a/NANVIX.md
+++ b/NANVIX.md
@@ -61,7 +61,7 @@ Or build directly with Make (advanced):
 
 ```bash
 # 1. Pull the Docker image
-docker pull ghcr.io/nanvix/toolchain-gcc:sha-34a3641
+docker pull ghcr.io/nanvix/toolchain-libffi:latest
 
 # 2. Download Nanvix sysroot
 curl -fsSL https://raw.githubusercontent.com/nanvix/nanvix/refs/heads/dev/scripts/get-nanvix.sh | bash -s -- nanvix-artifacts
@@ -132,7 +132,7 @@ The Makefile supports automatic Docker fallback when the native toolchain is not
 
 ```bash
 # Pull the Nanvix toolchain Docker image
-docker pull ghcr.io/nanvix/toolchain-gcc:sha-34a3641
+docker pull ghcr.io/nanvix/toolchain-libffi:latest
 
 # Build (Docker is used automatically if native toolchain is not found)
 make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/nanvix/sysroot-debug
@@ -144,7 +144,7 @@ make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/nanvix/sysroot-debu
 - If `NANVIX_TOOLCHAIN` points to a valid toolchain, it uses the native compiler
 - If the native toolchain is not found, it automatically uses Docker if available
 - Use `CONFIG_NANVIX_DOCKER=y` to force Docker usage even when native toolchain exists
-- Use `NANVIX_DOCKER_IMAGE` to specify a custom Docker image (default: `ghcr.io/nanvix/toolchain-gcc:sha-34a3641`)
+- Use `NANVIX_DOCKER_IMAGE` to specify a custom Docker image (default: `ghcr.io/nanvix/toolchain-libffi:latest`)
 
 ### Using Native Toolchain
 


### PR DESCRIPTION
## Summary

Replaces the "download release tarball and overlay it onto the working tree" bootstrap with on-demand autotools regeneration inside a project-specific Docker image, mirroring the pattern used by [`nanvix/cpython`](https://github.com/nanvix/cpython/tree/nanvix/v3.12.3/.nanvix/docker)'s `toolchain-python`.

## Motivation

`./z setup` previously fetched `libffi-3.4.6.tar.gz` and overlaid it onto the working tree whenever `./configure` was missing. That clobbered tracked files (notably `config.sub` — which we patch to recognize the `nanvix-*` host triple — and `README.md`), producing spurious diffs after every setup. The base `ghcr.io/nanvix/toolchain-gcc` image lacks autotools, so generating `configure` in-container required extending the image.

## Changes

### New `toolchain-libffi` image

- **`.nanvix/docker/Dockerfile`** — extends `ghcr.io/nanvix/toolchain-gcc:sha-34a3641` with `autoconf`, `automake`, `libtool`, `libltdl-dev`, `m4`, `texinfo`. `libltdl-dev` is required because `configure.ac` references `LT_SYS_SYMBOL_USCORE`, which lives in `ltdl.m4` (not `libtool.m4`) on Ubuntu 24.04 / libtool 2.4.7.
- **`.github/workflows/nanvix-docker-image.yml`** — builds and publishes `ghcr.io/nanvix/toolchain-libffi` to GHCR on pushes to `nanvix/**`, gated by path filters. PRs build but don't push. Tags: `sha-<commit>` always, plus `latest` on the default branch. Adapted from cpython's `docker-image.yml`.

### Build flow

- **`Makefile.nanvix`** — new `configure` target depending on `configure.ac`, `Makefile.am`, `acinclude.m4`, `m4/*.m4`, running `autoreconf -v -i -f`. The `-f` flag is required so `libtoolize` overwrites the stale in-tree libtool m4 set with the system copy. `$(CONFIGURED_MARKER)` now depends on `configure`. The idempotent `config.sub` `sed` patch is kept (defends against `autoreconf -i` copying a fresh `config.sub` from automake's data dir).
- **`.nanvix/z.py`** — removed `_ensure_configure()`, `_LIBFFI_VERSION`, `_LIBFFI_TARBALL_URL`, and the now-unused `tarfile` / `urllib.request` / `TemporaryDirectory` imports. `setup()` is now a thin delegation to `super().setup()`.

### Consumer-side updates

- **`.github/workflows/nanvix-ci.yml`** — both push/PR and scheduled jobs point at `ghcr.io/nanvix/toolchain-libffi:latest`.
- **`.nanvix/env.json`** — local default `NANVIX_DOCKER_IMAGE` switched to `ghcr.io/nanvix/toolchain-libffi:latest`.
- **`NANVIX.md`** — three documentation references updated.

## Verification

Locally:

```powershell
docker build -t toolchain-libffi:local .nanvix/docker
$env:NANVIX_DOCKER_IMAGE='toolchain-libffi:local'
./z build
```

Runs `autoreconf` → `configure` → cross-compile → link, producing `ffi_test.elf` successfully end-to-end.

## Rollout note

The first merge to a `nanvix/**` branch must publish `toolchain-libffi:latest` via the new `nanvix-docker-image` workflow before `nanvix-ci` can pull it. If CI fires before the image is available, re-run after the image-build workflow completes (or trigger `workflow_dispatch` on the docker-image workflow first).
