### PR TITLE
Add toolchain-libffi Docker image and publish workflow

### DIFF
--- a/.github/workflows/nanvix-docker-image.yml
+++ b/.github/workflows/nanvix-docker-image.yml
@@ -1,0 +1,60 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+name: Docker Image
+
+on:
+  push:
+    branches: ["nanvix/**"]
+    paths:
+      - ".nanvix/docker/Dockerfile"
+      - ".github/workflows/nanvix-docker-image.yml"
+  pull_request:
+    branches: ["nanvix/**"]
+    paths:
+      - ".nanvix/docker/Dockerfile"
+      - ".github/workflows/nanvix-docker-image.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: nanvix/toolchain-libffi
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .nanvix/docker
+          file: .nanvix/docker/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.nanvix/docker/Dockerfile
+++ b/.nanvix/docker/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# toolchain-libffi — Nanvix GCC toolchain + autotools for libffi
+# cross-compilation. Published as ghcr.io/nanvix/toolchain-libffi.
+#
+# The base image ships the i686-nanvix cross-compiler but does not include
+# autoconf / automake / libtool. libffi's Makefile.nanvix runs `autoreconf -i`
+# from the configure target, so those tools must be available inside the
+# container.
+
+FROM ghcr.io/nanvix/toolchain-gcc:sha-34a3641
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        autoconf \
+        automake \
+        libtool \
+        libltdl-dev \
+        m4 \
+        texinfo \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Introduce a project-specific Docker image extending the base Nanvix GCC toolchain with the autotools required to regenerate libffi's build system inside the container. Mirrors the pattern used by `nanvix/cpython`'s `toolchain-python` image.

The base `ghcr.io/nanvix/toolchain-gcc` image ships the `i686-nanvix` cross compiler but does not include autoconf/automake/libtool. `Makefile.nanvix` invokes `autoreconf -v -i -f` from its `configure` target, so those tools must be available inside the build container.

## Changes

* `.nanvix/docker/Dockerfile`
  - `FROM ghcr.io/nanvix/toolchain-gcc:sha-34a3641` (pinned by sha for reproducibility, matching CI's existing pin).
  - Installs: `autoconf`, `automake`, `libtool`, `libltdl-dev`, `m4`, `texinfo`.
    `libltdl-dev` is required because `configure.ac` references `LT_SYS_SYMBOL_USCORE`, which lives in `ltdl.m4` (not `libtool.m4`) on Ubuntu 24.04 / libtool 2.4.7.
  - Cleans `/var/lib/apt/lists/*` to keep the layer small.

* `.github/workflows/nanvix-docker-image.yml`
  - Builds and publishes `ghcr.io/nanvix/toolchain-libffi` to GHCR on pushes to `nanvix/**` branches, gated by path filters on the Dockerfile and workflow file.
  - PRs build but do not push (verification only).
  - Tags: `sha-<commit>` on every build, `latest` on the default branch, and `latest` on manual `workflow_dispatch` runs (allows maintainers to force-republish from any branch).
  - Adapted from `nanvix/cpython`'s `.github/workflows/docker-image.yml`.

## Verification

Verified locally:
```
docker build -t toolchain-libffi:local .nanvix/docker
NANVIX_DOCKER_IMAGE=toolchain-libffi:local ./z build
```
produces `ffi_test.elf` successfully end-to-end (`autoreconf` → `configure` → cross-compile → link).

## Follow-up

This PR only introduces and publishes the image; nothing in the build currently consumes it. A follow-up PR (`enhancement-nanvix-consume`) will switch `nanvix-ci.yml`, `.nanvix/env.json`, `.nanvix/z.py`, `Makefile.nanvix`, and `NANVIX.md` to consume `ghcr.io/nanvix/toolchain-libffi:latest` once this PR merges and the image has been published.

Supersedes the image half of #213.