### PR TITLE
Consume toolchain-libffi image for builds and tests

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -35,7 +35,7 @@ jobs:
       skip-full-test-modes: "[]"
       caller-event-name: ${{ github.event_name }}
       windows-test: true
-      docker-image: "ghcr.io/nanvix/toolchain-libffi:latest" # yamllint disable-line rule:line-length
+      docker-image: "ghcr.io/nanvix/toolchain-libffi:sha-fce3172" # yamllint disable-line rule:line-length
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
       skip-full-test-modes: "[]"
       caller-event-name: "schedule"
       windows-test: true
-      docker-image: "ghcr.io/nanvix/toolchain-libffi:latest" # yamllint disable-line rule:line-length
+      docker-image: "ghcr.io/nanvix/toolchain-libffi:sha-fce3172" # yamllint disable-line rule:line-length
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -35,7 +35,7 @@ jobs:
       skip-full-test-modes: "[]"
       caller-event-name: ${{ github.event_name }}
       windows-test: true
-      docker-image: "ghcr.io/nanvix/toolchain-gcc:sha-34a3641" # yamllint disable-line rule:line-length
+      docker-image: "ghcr.io/nanvix/toolchain-libffi:latest" # yamllint disable-line rule:line-length
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
       skip-full-test-modes: "[]"
       caller-event-name: "schedule"
       windows-test: true
-      docker-image: "ghcr.io/nanvix/toolchain-gcc:sha-34a3641" # yamllint disable-line rule:line-length
+      docker-image: "ghcr.io/nanvix/toolchain-libffi:latest" # yamllint disable-line rule:line-length
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -35,7 +35,7 @@ jobs:
       skip-full-test-modes: "[]"
       caller-event-name: ${{ github.event_name }}
       windows-test: true
-      docker-image: "ghcr.io/nanvix/toolchain-libffi:sha-fce3172" # yamllint disable-line rule:line-length
+      docker-image: "ghcr.io/nanvix/toolchain-libffi:latest" # yamllint disable-line rule:line-length
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
       skip-full-test-modes: "[]"
       caller-event-name: "schedule"
       windows-test: true
-      docker-image: "ghcr.io/nanvix/toolchain-libffi:sha-fce3172" # yamllint disable-line rule:line-length
+      docker-image: "ghcr.io/nanvix/toolchain-libffi:latest" # yamllint disable-line rule:line-length
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,8 @@ __pycache__
 .docker_home
 emsdk
 test-results
+
+# Nanvix
+ffi_test.elf
+i686-pc-nanvix/include/ffi.h
+i686-pc-nanvix/include/ffitarget.h

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -14,11 +14,8 @@ Usage:
 
 import shutil
 import sys
-import tarfile
 import tempfile
-import urllib.request
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
 from nanvix_zutil import (
     CFG_SYSROOT,
@@ -36,12 +33,6 @@ _MAKE_VAR_TOOLCHAIN = "NANVIX_TOOLCHAIN"
 _MAKE_VAR_PLATFORM = "PLATFORM"
 _MAKE_VAR_PROCESS_MODE = "PROCESS_MODE"
 _MAKE_VAR_MEMORY_SIZE = "MEMORY_SIZE"
-
-_LIBFFI_VERSION = "3.4.6"
-_LIBFFI_TARBALL_URL = (
-    f"https://github.com/libffi/libffi/releases/download/v{_LIBFFI_VERSION}/"
-    f"libffi-{_LIBFFI_VERSION}.tar.gz"
-)
 
 
 IS_WINDOWS = sys.platform == "win32"
@@ -83,40 +74,15 @@ class LibffiBuild(ZScript):
         args.extend(targets)
         return args
 
-    def _ensure_configure(self) -> None:
-        """Download the release tarball if ``./configure`` is missing.
-
-        Git checkouts of libffi do not include the autotools-generated
-        ``configure`` script.  When it is absent we fetch the official
-        release tarball and overlay it onto the working tree.
-        """
-        configure = self.repo_root / "configure"
-        if configure.exists():
-            return
-
-        log.info("configure script not found — downloading release tarball")
-        with TemporaryDirectory() as tmp:
-            tarball = Path(tmp) / f"libffi-{_LIBFFI_VERSION}.tar.gz"
-            urllib.request.urlretrieve(_LIBFFI_TARBALL_URL, tarball)
-            with tarfile.open(tarball, "r:gz") as tf:
-                if sys.version_info >= (3, 12):
-                    tf.extractall(tmp, filter="data")
-                else:
-                    tf.extractall(tmp)  # noqa: S202
-            extracted = Path(tmp) / f"libffi-{_LIBFFI_VERSION}"
-            for item in extracted.iterdir():
-                dest = self.repo_root / item.name
-                if item.is_dir():
-                    shutil.copytree(item, dest, dirs_exist_ok=True)
-                else:
-                    shutil.copy2(item, dest)
-        log.info("configure script ready")
-
     def setup(self) -> bool:
-        """Download the Nanvix sysroot and prepare autotools sources."""
-        ok = super().setup()
-        self._ensure_configure()
-        return ok
+        """Download the Nanvix sysroot.
+
+        The autotools build system (``configure``, ``Makefile.in``, ...)
+        is regenerated on demand by ``Makefile.nanvix`` inside the Docker
+        toolchain image (see the ``configure`` target there).  No
+        host-side autotools install is required.
+        """
+        return super().setup()
 
     def build(self) -> None:
         """Cross-compile libffi.a and ffi_test.elf for Nanvix.

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -21,11 +21,27 @@ from nanvix_zutil import (
     CFG_SYSROOT,
     EXIT_MISSING_DEP,
     TOOLCHAIN_CONTAINER_PATH,
+    DockerConfig,
     ZScript,
     log,
     make_initrd,
     run,
 )
+
+# Build artifacts produced inside the Docker container that must be
+# copied back to the host workspace.  Required on Windows where the
+# build runs in a container-local directory (``/tmp/build``) instead of
+# the mounted workspace; without this list, ``ffi_test.elf`` would be
+# unreachable to the native test runner and the package step would not
+# see ``libffi.a`` / headers on the host filesystem.  Paths are relative
+# to the container build dir.
+_BUILD_DIR = "i686-pc-nanvix"
+_OUTPUT_FILES = [
+    "ffi_test.elf",
+    f"{_BUILD_DIR}/.libs/libffi.a",
+    f"{_BUILD_DIR}/include/ffi.h",
+    f"{_BUILD_DIR}/include/ffitarget.h",
+]
 
 # Makefile variable names (build-system-specific).
 _MAKE_VAR_HOME = "NANVIX_HOME"
@@ -40,6 +56,18 @@ IS_WINDOWS = sys.platform == "win32"
 
 class LibffiBuild(ZScript):
     """Build script for nanvix/libffi."""
+
+    def docker_config(self, image: str) -> DockerConfig:
+        """Extend the default Docker config with build output copy-back.
+
+        On Windows the build runs in a container-local directory to avoid
+        the slow mounted-workspace I/O penalty.  ``output_files`` tells
+        ``nanvix_zutil`` which artifacts to copy back to the host after
+        the build so subsequent test / package steps can find them.
+        """
+        cfg = super().docker_config(image)
+        cfg.output_files = list(_OUTPUT_FILES)
+        return cfg
 
     def _make_args(self, *targets: str) -> list[str]:
         """Build the common make argument list."""

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -81,9 +81,18 @@ NANVIX_LIBS := -Wl,--start-group \
 
 all: build ffi_test$(EXE)
 
-$(CONFIGURED_MARKER):
-	@# Patch config.sub to recognize nanvix (idempotent; defensive against
-	@# tarball overlay performed by .nanvix/z.py's _ensure_configure()).
+# Regenerate the autotools build system from configure.ac / Makefile.am.
+# Runs inside the Docker toolchain image (which provides autoconf,
+# automake, and libtool), so no autotools install is required on the
+# host.  Re-runs only when the autotools inputs change.
+configure: configure.ac Makefile.am acinclude.m4 $(wildcard m4/*.m4)
+	autoreconf -v -i -f
+	@touch configure
+
+$(CONFIGURED_MARKER): configure
+	@# Patch config.sub to recognize nanvix (idempotent; defends against
+	@# autoreconf -i replacing it with an upstream copy from automake's
+	@# data dir).
 	@if [ -f config.sub ] && ! grep -q 'nanvix' config.sub; then \
 	  sed -i 's/| fiwix\* )/| fiwix* | nanvix* )/' config.sub; \
 	fi

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -87,7 +87,7 @@ all: build ffi_test$(EXE)
 # host.  Re-runs only when the autotools inputs change.
 configure: configure.ac Makefile.am acinclude.m4 $(wildcard m4/*.m4)
 	autoreconf -v -i -f
-	@touch configure
+	@test -f configure
 
 $(CONFIGURED_MARKER): configure
 	@# Patch config.sub to recognize nanvix (idempotent; defends against

--- a/NANVIX.md
+++ b/NANVIX.md
@@ -61,7 +61,7 @@ Or build directly with Make (advanced):
 
 ```bash
 # 1. Pull the Docker image
-docker pull ghcr.io/nanvix/toolchain-gcc:sha-34a3641
+docker pull ghcr.io/nanvix/toolchain-libffi:latest
 
 # 2. Download Nanvix sysroot
 curl -fsSL https://raw.githubusercontent.com/nanvix/nanvix/refs/heads/dev/scripts/get-nanvix.sh | bash -s -- nanvix-artifacts
@@ -132,7 +132,7 @@ The Makefile supports automatic Docker fallback when the native toolchain is not
 
 ```bash
 # Pull the Nanvix toolchain Docker image
-docker pull ghcr.io/nanvix/toolchain-gcc:sha-34a3641
+docker pull ghcr.io/nanvix/toolchain-libffi:latest
 
 # Build (Docker is used automatically if native toolchain is not found)
 make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/nanvix/sysroot-debug
@@ -144,7 +144,7 @@ make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/nanvix/sysroot-debu
 - If `NANVIX_TOOLCHAIN` points to a valid toolchain, it uses the native compiler
 - If the native toolchain is not found, it automatically uses Docker if available
 - Use `CONFIG_NANVIX_DOCKER=y` to force Docker usage even when native toolchain exists
-- Use `NANVIX_DOCKER_IMAGE` to specify a custom Docker image (default: `ghcr.io/nanvix/toolchain-gcc:sha-34a3641`)
+- Use `NANVIX_DOCKER_IMAGE` to specify a custom Docker image (default: `ghcr.io/nanvix/toolchain-libffi:latest`)
 
 ### Using Native Toolchain
 

--- a/NANVIX.md
+++ b/NANVIX.md
@@ -138,7 +138,7 @@ docker pull ghcr.io/nanvix/toolchain-libffi:latest
 make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/nanvix/sysroot-debug
 ```
 
-> **Note:** The sysroot (`NANVIX_HOME`) must contain `lib/libposix.a` and `lib/user.ld` from a Nanvix build. The libffi source tree must also have a pre-generated `configure` script (use the release tarball if building from a git checkout).
+> **Note:** The sysroot (`NANVIX_HOME`) must contain `lib/libposix.a` and `lib/user.ld` from a Nanvix build. The autotools build system (`configure`, `Makefile.in`, etc.) is regenerated automatically via `autoreconf` inside the Docker toolchain image, so a git checkout is sufficient — no release tarball is required.
 
 **Docker Fallback Behavior:**
 - If `NANVIX_TOOLCHAIN` points to a valid toolchain, it uses the native compiler


### PR DESCRIPTION
**Depends on #214 — keep as draft until #214 merges and `:latest` is published to GHCR.**

Switch libffi's Nanvix build away from the previous "download upstream release tarball and overlay it onto the working tree" bootstrap, and toward regenerating the autotools build system on demand inside the Docker toolchain image. Consume the new `ghcr.io/nanvix/toolchain-libffi` image (introduced in #214) which ships autoconf, automake, libtool, and libltdl-dev on top of `toolchain-gcc`.

## Motivation

The old `_ensure_configure()` path in `.nanvix/z.py` fetched `libffi-3.4.6.tar.gz` and copied its contents over the working tree whenever `./configure` was missing. That overlay clobbered tracked files (notably `config.sub`, which we patch to recognize the `nanvix-*` host triple, and `README.md`), producing spurious working-tree diffs after every `./z setup`. Generating `configure` inside the container removes the tarball dependency entirely and keeps the working tree clean.

## Changes

* `.nanvix/z.py`
  - Remove `_ensure_configure()`, `_LIBFFI_VERSION`, `_LIBFFI_TARBALL_URL`, and the `tarfile` / `urllib.request` / `TemporaryDirectory` imports that only existed to support it.
  - `setup()` now just delegates to `super().setup()` (sysroot download). Updated docstring documents that autotools regeneration is handled by `Makefile.nanvix` inside the container.

* `Makefile.nanvix`
  - Add a `configure` target depending on `configure.ac`, `Makefile.am`, `acinclude.m4` and `m4/*.m4`. It runs `autoreconf -v -i -f`; the `-f` is required so libtoolize overwrites the stale in-tree libtool m4 set with the system copy from libtool 2.4.7.
  - Make the `$(CONFIGURED_MARKER)` rule depend on `configure`, so a fresh checkout regenerates the build system before `./configure` runs.
  - Keep the idempotent `config.sub` sed patch but reword the comment: it now guards against `autoreconf -i` copying a fresh `config.sub` from automake's data dir, not against the (now-removed) tarball overlay.

* `.github/workflows/nanvix-ci.yml`
  - Point both the push/PR job and the scheduled job at `ghcr.io/nanvix/toolchain-libffi:latest`. This image contains the autotools that the new `configure` target invokes.

* `NANVIX.md`
  - Update the three references to the Docker image (Quick Start, "Using Docker (Direct Make)" pull command, and the default-image note under Docker fallback behavior) to point at `ghcr.io/nanvix/toolchain-libffi:latest`.

## Verification

Verified locally with:
```
docker build -t toolchain-libffi:local .nanvix/docker
NANVIX_DOCKER_IMAGE=toolchain-libffi:local ./z build
```
which runs `autoreconf` → `configure` → cross-compile and produces `ffi_test.elf` successfully.

## Rollout

1. Merge #214 first. Its image-publish workflow runs on the resulting push to `nanvix/v3.4.6` (the default branch of this fork), which publishes `ghcr.io/nanvix/toolchain-libffi:latest` to GHCR.
2. Rebase this PR onto the updated base and mark it ready for review. CI will then be able to pull the image successfully.

Supersedes the consumer half of #213.