### PR TITLE
[ci] Sync zutils v0.10.3

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -28,7 +28,7 @@ jobs:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.2
     with:
-      zutil-version: "v0.10.2"
+      zutil-version: "v0.10.3"
       platforms: '["microvm"]'
       memory-sizes: "[\"128mb\",\"256mb\"]"
       windows-matrix-exclude: '[]'
@@ -44,7 +44,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.2
     with:
-      zutil-version: "v0.10.2"
+      zutil-version: "v0.10.3"
       platforms: '["microvm"]'
       memory-sizes: "[\"128mb\",\"256mb\"]"
       windows-matrix-exclude: '[]'

--- a/z.ps1
+++ b/z.ps1
@@ -11,17 +11,33 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-$zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
-    $env:NANVIX_ZUTIL_VERSION
-}
-else {
-    "0.10.2"
-}
-$zutilVersion = $zutilVersion -replace "^v", ""
-
 # z.ps1 lives at the repository root, so use its directory directly
 # instead of relying on git to discover the top-level checkout directory.
 $repoRoot = $PSScriptRoot
+$versionFile = Join-Path $repoRoot ".zutils-version"
+
+# Resolve the pinned nanvix-zutil version. `.zutils-version` at the repo
+# root is the sole source of truth: no env-var override, no GitHub fetch.
+# Downstream consumers commit this file; CI and developers see the same
+# pin without ambient configuration.
+function Resolve-ZutilVersion {
+    if (-not (Test-Path -LiteralPath $versionFile)) {
+        throw "Error: $versionFile not found.`n       Create it with a pinned nanvix-zutil version, e.g. 'v0.10.2'."
+    }
+    $content = Get-Content -LiteralPath $versionFile -Raw
+    $raw = if ($null -eq $content) { "" } else { $content.Trim() }
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        throw "Error: $versionFile is empty."
+    }
+    if ($raw -notmatch '^v?\d+\.\d+\.\d+([.-][A-Za-z0-9.-]+)?$') {
+        throw "Error: invalid nanvix-zutil version '$raw' in $versionFile (expected vX.Y.Z)."
+    }
+    return $raw
+}
+
+$rawZutilVersion = Resolve-ZutilVersion
+$zutilVersion = $rawZutilVersion -replace "^v", ""
+
 $venvDir = Join-Path $repoRoot ".nanvix\venv"
 $venvPython = Join-Path $venvDir "Scripts\python.exe"
 $venvZutil = Join-Path $venvDir "Scripts\nanvix-zutil.exe"
@@ -135,8 +151,7 @@ function NewZutilVenv {
 
 function Bootstrap {
     param([string]$Reason = "not found")
-    # Pin nanvix-zutil version for reproducible bootstrapping.
-    # Override with NANVIX_ZUTIL_VERSION env var if needed.
+    # nanvix-zutil version comes from .zutils-version (resolved above).
     Write-Information "nanvix-zutil ${Reason} -- bootstrapping nanvix-zutil==${zutilVersion}..." -InformationAction Continue
 
     $wheelUrl = "https://github.com/nanvix/zutils/releases/download/v${zutilVersion}/nanvix_zutil-${zutilVersion}-py3-none-any.whl"

--- a/z.sh
+++ b/z.sh
@@ -7,11 +7,36 @@
 
 set -euo pipefail
 
-PINNED_VERSION="0.10.2"
-RAW_ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-$PINNED_VERSION}"
-ZUTIL_VERSION="${RAW_ZUTIL_VERSION#v}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
 VENV="$REPO_ROOT/.nanvix/venv"
+VERSION_FILE="$REPO_ROOT/.zutils-version"
+
+# Resolve the pinned nanvix-zutil version. `.zutils-version` at the repo
+# root is the sole source of truth: no env-var override, no GitHub fetch.
+# Downstream consumers commit this file; CI and developers see the same
+# pin without ambient configuration.
+function _resolve_zutil_version() {
+    # RAW_ZUTIL_VERSION and ZUTIL_VERSION are intentionally global;
+    # they are consumed by bootstrap() below.
+    if [ ! -f "$VERSION_FILE" ]; then
+        echo "Error: $VERSION_FILE not found." >&2
+        echo "       Create it with a pinned nanvix-zutil version, e.g. 'v0.10.2'." >&2
+        exit 1
+    fi
+    local raw
+    raw="$(tr -d '[:space:]' <"$VERSION_FILE")"
+    if [ -z "$raw" ]; then
+        echo "Error: $VERSION_FILE is empty." >&2
+        exit 1
+    fi
+    if [[ ! "$raw" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([.-][[:alnum:].-]+)?$ ]]; then
+        echo "Error: invalid nanvix-zutil version '$raw' in $VERSION_FILE (expected vX.Y.Z)." >&2
+        exit 1
+    fi
+    RAW_ZUTIL_VERSION="$raw"
+    ZUTIL_VERSION="${RAW_ZUTIL_VERSION#v}"
+}
+_resolve_zutil_version
 
 # Resolve venv layout (bin/ vs Scripts/) based on what exists on disk.
 # Can be called before venv creation to initialize default paths; call it
@@ -126,8 +151,7 @@ function bootstrap_local() {
 }
 
 function bootstrap() {
-    # Pin nanvix-zutil version for reproducible bootstrapping.
-    # Override with NANVIX_ZUTIL_VERSION env var if needed.
+    # nanvix-zutil version comes from .zutils-version (resolved above).
     local reason="${1:-not found}"
     echo "nanvix-zutil ${reason} -- bootstrapping nanvix-zutil==${ZUTIL_VERSION}..." >&2
 


### PR DESCRIPTION
Automated sync with [`v0.10.3`](https://github.com/nanvix/zutils/releases/tag/v0.10.3):
- Bumps `zutil-version` in caller workflows.
- Copies bootstrapper templates (`z`, `z.sh`, `z.ps1`) from release assets.
- Pins `nanvix-version` to `0.15.26` in `.nanvix/nanvix.toml`.

Generated by the [Update Zutils](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-zutils.yml) workflow.