### PR TITLE
[build] E: Link libnvx_crt0.a into test ELF, drop --allow-multiple-definition

### DIFF
--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -79,6 +79,7 @@ CC := $(NANVIX_TOOLCHAIN)/bin/i686-nanvix-gcc
 AR := $(NANVIX_TOOLCHAIN)/bin/i686-nanvix-ar
 NANVIX_LDFLAGS := -static -L$(SYSROOT_PATH)/lib -T$(SYSROOT_PATH)/lib/user.ld
 NANVIX_LIBS := -Wl,--start-group \
+  $(SYSROOT_PATH)/lib/libnvx_crt0.a \
   $(SYSROOT_PATH)/lib/libposix.a \
   $(NANVIX_TOOLCHAIN)/i686-nanvix/lib/libc.a \
   $(NANVIX_TOOLCHAIN)/i686-nanvix/lib/libm.a \
@@ -138,7 +139,7 @@ build: $(CONFIGURED_MARKER)
 ffi_test$(EXE): build
 	@printf '#include <stdio.h>\n#include <ffi.h>\nint main() {\n  ffi_cif cif;\n  ffi_type *args[1];\n  args[0] = &ffi_type_uint;\n  if (ffi_prep_cif(&cif, FFI_DEFAULT_ABI, 1, &ffi_type_uint, args) == FFI_OK) {\n    printf("FFI_TEST: PASS cif_prep\\n");\n  } else {\n    printf("FFI_TEST: FAIL cif_prep\\n"); return 1;\n  }\n  return 0;\n}\n' > _ffi_test.c
 	$(CC) -O2 -I$(FFI_INCLUDE) _ffi_test.c $(LIBFFI) \
-	    $(NANVIX_LDFLAGS) -Wl,--allow-multiple-definition $(NANVIX_LIBS) \
+	    $(NANVIX_LDFLAGS) $(NANVIX_LIBS) \
 	    -o $@
 	@rm -f _ffi_test.c
 	@echo "  OK: $@ ($$(wc -c < $@) bytes)"


### PR DESCRIPTION
## Summary

[nanvix/nanvix#2453](https://github.com/nanvix/nanvix/pull/2453) (already upstream) moved the `_start` entry point out of `libposix.a` into a new `libnvx_crt0.a`. This PR makes two changes to the test ELF link line:

1. **Add `libnvx_crt0.a`** so the linker resolves `_start` from it; without this the linker silently picks newlib's weak default `_start` and the test hangs at startup with no diagnostic output.
2. **Drop `-Wl,--allow-multiple-definition`** that was previously needed to coalesce duplicate strong symbols (`__kcall_*`, `_do_exit_thread`, `_do_start_thread`, `_do_start`) appearing in both `libnvx_crt0.a` and `libposix.a`. All of those duplicates are now resolved upstream (see Dependencies below), so the flag is no longer required.

## Dependencies

This PR assumes the following have already merged and the toolchain image has been republished:

- [nanvix/nanvix#2487](https://github.com/nanvix/nanvix/pull/2487) — `sys-ffi` crate split that removes the duplicate `__kcall_*` / `_do_exit_thread` / `_do_start_thread` strong symbols from `libnvx_crt0.a`.
- [nanvix/newlib#17](https://github.com/nanvix/newlib/pull/17) — declares newlib's `_do_start` as `.weak` so `libnvx_crt0`'s strong SSE-aligned override wins cleanly without `-Wl,--allow-multiple-definition`.
- [nanvix/toolchain-gcc#14](https://github.com/nanvix/toolchain-gcc/pull/14) — pins the new newlib commit and triggers a republish of `ghcr.io/nanvix/toolchain-gcc`.

If those have not landed, the link line will fail with `multiple definition of __kcall_*` errors against the unpatched toolchain image.
