### PR TITLE
Rm release override

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -26,8 +26,6 @@ from nanvix_zutil import (
     log,
     make_initrd,
     run,
-    load_manifest,
-    package,
 )
 from nanvix_zutil.paths import (
     dist_dir,
@@ -37,7 +35,6 @@ from nanvix_zutil.paths import (
     out_dir,
     repo_root,
     test_out,
-    release_dir,
 )
 
 # Artifacts produced inside the Docker container that must be copied
@@ -355,27 +352,6 @@ class LibffiBuild(ZScript):
             err_msg = f"{len(failed)} test(s) failed: {msg}"
             raise RuntimeError(err_msg)
         print(f"\t\t*** All {len(test_binaries)} tests PASSED ***")
-
-    def release(self) -> None:
-        """Package the release archive named per build configuration.
-
-        The base :meth:`ZScript.release` packages ``release_dir()`` under the
-        bare package name, so every matrix configuration emits an
-        identically-named archive; in CI these collide and overwrite one
-        another, leaving the published release with only generic assets.
-        Dependents resolve assets by the pattern
-        ``{name}-{machine}-{mode}-{mem}`` (e.g.
-        ``{name}-microvm-multi-process-128mb``), so the archive must carry that
-        name for dependency installation to succeed.
-        """
-        manifest = load_manifest()
-        name = (
-            f"{manifest.name}"
-            f"-{self.config.machine}"
-            f"-{self.config.deployment_mode}"
-            f"-{self.config.memory_size}"
-        )
-        package([release_dir()], dist_dir(), name)
 
     def clean(self) -> None:
         """Remove build artifacts."""


### PR DESCRIPTION
Removes the redundant release override; the base `ZScript.release()` in nanvix-zutil v0.12.0 already implements the same suffix-naming pattern (`{name}-{machine}-{deployment_mode}-{memory_size}`).

Verified the full lifecycle on Linux and Windows before and after the change: release archive filenames and contents match.

Towards nanvix/zutils#191.