### PR TITLE
[build] F: Restore WSL-safe out-of-tree configure

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -12,6 +12,7 @@ Usage:
     ./z clean     # Remove build artifacts
 """
 
+import shutil
 import sys
 import tempfile
 from pathlib import Path
@@ -38,30 +39,12 @@ from nanvix_zutil.paths import (
 # Artifacts produced inside the Docker container that must be copied
 # back to the host workspace on Windows tar-copy mode (where the build
 # runs in container-local /tmp/build instead of the mounted workspace).
-# Two categories:
-#   * repo-root paths where the Makefile leaves link-step output and the
-#     standalone test expects to find it;
-#   * install-staged paths under .nanvix/out/{release,test} required by
-#     `./z release` (see _staged_output_files()).
 _OUTPUT_FILES = [
     # Makefile leaves ffi_test.elf at the repo root; the standalone test
     # loads it from there. The staged copy under test_out() is for the
     # release tarball.
     "ffi_test.elf",
 ]
-
-
-def _staged_output_files() -> list[str]:
-    """Return install-staged artifact paths (relative to repo_root()) so
-    Windows tar-copy mode also copies them back to the host workspace.
-    """
-    root = repo_root()
-    return [
-        str((dev_out() / "lib" / "libffi.a").relative_to(root)),
-        str((dev_out() / "include" / "ffi.h").relative_to(root)),
-        str((dev_out() / "include" / "ffitarget.h").relative_to(root)),
-        str((test_out() / "ffi_test.elf").relative_to(root)),
-    ]
 
 
 # Makefile variable names (build-system-specific).
@@ -96,11 +79,11 @@ class LibffiBuild(ZScript):
 
         On Windows the build runs in a container-local directory to avoid
         the slow mounted-workspace I/O penalty.  ``output_files`` tells
-        ``nanvix_zutil`` which artifacts to copy back to the host after
-        the build so subsequent test / package steps can find them.
+        ``nanvix_zutil`` to copy the root test ELF back after the build.
+        Staged outputs are written directly to the workspace bind mount.
         """
         cfg = super().docker_config(image)
-        cfg.output_files = list(_OUTPUT_FILES) + _staged_output_files()
+        cfg.output_files = list(_OUTPUT_FILES)
         return cfg
 
     def _make_args(self, *targets: str) -> list[str]:
@@ -345,6 +328,9 @@ class LibffiBuild(ZScript):
             "clean",
             cwd=repo_root(),
         )
+        output = out_dir()
+        if output.exists():
+            shutil.rmtree(output)
 
 
 if __name__ == "__main__":

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -122,6 +122,10 @@ $(CONFIGURED_MARKER): configure
 	@# configure.host fall through to TARGET=X86_64, pulling in 64-bit
 	@# sources for a 32-bit build and producing undefined references to
 	@# ffi_prep_cif_machdep / ffi_prep_closure_loc at link time.
+	@# Enter the build directory explicitly. AX_ENABLE_BUILDDIR otherwise moves
+	@# an open config.log during recursive configure, which fails on WSL 9p.
+	mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && \
 	CC="$(CC)" \
 	CXX="$(CXX)" \
 	AR="$(AR)" \
@@ -132,13 +136,14 @@ $(CONFIGURED_MARKER): configure
 	ac_cv_sizeof_size_t=4 \
 	ac_cv_sizeof_double=8 \
 	ac_cv_sizeof_long_double=12 \
-	./configure --host=i686-nanvix --build=x86_64-pc-linux-gnu \
+	../configure --srcdir=.. \
+	            --host=i686-nanvix --build=x86_64-pc-linux-gnu \
 	            --prefix="$(INSTALL_PREFIX)" \
 	            --disable-shared --enable-static --disable-docs
 	touch $(CONFIGURED_MARKER)
 
 build: $(CONFIGURED_MARKER)
-	$(MAKE) -j$$(nproc)
+	$(MAKE) -C $(BUILD_DIR) -j$$(nproc)
 
 ffi_test$(EXE): build
 	@printf '#include <stdio.h>\n#include <ffi.h>\nint main() {\n  ffi_cif cif;\n  ffi_type *args[1];\n  args[0] = &ffi_type_uint;\n  if (ffi_prep_cif(&cif, FFI_DEFAULT_ABI, 1, &ffi_type_uint, args) == FFI_OK) {\n    printf("FFI_TEST: PASS cif_prep\\n");\n  } else {\n    printf("FFI_TEST: FAIL cif_prep\\n"); return 1;\n  }\n  return 0;\n}\n' > _ffi_test.c
@@ -169,8 +174,8 @@ test: test-functional
 # ===========================================================================
 
 clean:
-	-$(MAKE) clean 2>/dev/null || true
+	-$(MAKE) -C $(BUILD_DIR) clean 2>/dev/null || true
 	rm -f $(CONFIGURED_MARKER) ffi_test$(EXE)
-	rm -rf $(OUT_DIR)
+	rm -rf $(BUILD_DIR)
 
 .PHONY: all build install clean test test-functional


### PR DESCRIPTION
Restore the out-of-tree libffi configure path that was previously carried only on feat/distro-windows-wsl-support and was omitted when the v0.21.22 SDK update advanced the default branch. This avoids Autoconf recursively moving its active config.log on WSL 9p. Validated by the focused nanvix-distro regression and the full 54-test distro suite.